### PR TITLE
blog.sh: extend gh pr create retry budget

### DIFF
--- a/tools/video-to-blog/blog.sh
+++ b/tools/video-to-blog/blog.sh
@@ -145,9 +145,10 @@ $PR_BODY"
 
 # gh pr create races GitHub's branch indexing on a fresh push: the API
 # can briefly think there are "No commits between master and <branch>".
-# Retry a few times before giving up.
+# Retry with a generous budget — indexing has been observed to take >1min.
 PR_URL=""
-for attempt in 1 2 3 4 5; do
+MAX_ATTEMPTS=10
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   if PR_URL=$(gh pr create \
       --repo "$REPO_FULL" \
       --base master \
@@ -156,9 +157,10 @@ for attempt in 1 2 3 4 5; do
       --body "$PR_BODY" 2>&1); then
     break
   fi
-  if [[ $attempt -lt 5 ]]; then
-    sleep $(( attempt * 5 ))
-    echo "  gh pr create retry $attempt ..."
+  if [[ $attempt -lt $MAX_ATTEMPTS ]]; then
+    delay=$(( attempt < 5 ? attempt * 5 : 30 ))
+    echo "  gh pr create retry $attempt (sleep ${delay}s) ..."
+    sleep "$delay"
   else
     echo "$PR_URL" >&2
     exit 1


### PR DESCRIPTION
## Summary
- The previous retry loop topped out at 5 attempts with linear backoff totalling ~50s. GitHub's branch indexing has been observed to take longer (>1min) on a fresh push, leading to all retries failing with `No commits between master and <branch>` (e.g. PR #9 had to be opened manually).
- Bump to 10 attempts. First 4 retries keep the linear ramp; remaining retries cap at 30s. Total worst-case wait grows to ~3min.

## Test plan
- [x] Next `blog.sh` run that hits the indexing race should now succeed without manual intervention.