### PR TITLE
blog: render cover thumbnail on index, fix dek extraction

### DIFF
--- a/public/blog/posts.json
+++ b/public/blog/posts.json
@@ -3,14 +3,14 @@
     "slug": "sequoias-ai-thesis-a-computation-revolution-not-a-faster",
     "title_en": "Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet",
     "date": "2026-05-08",
-    "dek_en": "![Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet](/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png)",
+    "dek_en": "At Sequoia Capital's AI Summit, partners Pat Grady, Sonya Huang, and Konstantine Buhler argued that the AI wave is categorically different from every prior tech cycle — large enough to swallow software *and* services, fast enough to compres",
     "tags": [],
     "languages": [
       "en",
       "zh"
     ],
     "title_zh": "红杉资本三位合伙人的 AI 论断：计算革命、长周期智能体，与 99.9% 认知工作的迁移",
-    "dek_zh": "![Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet](/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png)",
+    "dek_zh": "在最近一场红杉资本主办的 AI 峰会上，红杉的三位核心合伙人帕特·格雷迪（Pat Grady）、索尼娅·黄（Sonya Huang）与康斯坦丁·布勒（Konstantine Buhler）联合给出了他们对这一波 AI 浪潮的整体判断：这不是又一次通信革命，而是一次**计算革命**；长周期智能体已经到位，服务正在变成新的软件；最终，99.9% 的认知工作会像当年的体力劳动一样被机器接管。这篇博客整理了三位合伙人在演讲中的核心观点。",
     "source": "https://www.youtube.com/watch?v=BE2CR9YT8_k",
     "image": "/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png",
     "labels": [

--- a/public/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster/meta.json
+++ b/public/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster/meta.json
@@ -2,14 +2,14 @@
   "slug": "sequoias-ai-thesis-a-computation-revolution-not-a-faster",
   "title_en": "Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet",
   "date": "2026-05-08",
-  "dek_en": "![Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet](/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png)",
+  "dek_en": "At Sequoia Capital's AI Summit, partners Pat Grady, Sonya Huang, and Konstantine Buhler argued that the AI wave is categorically different from every prior tech cycle — large enough to swallow software *and* services, fast enough to compres",
   "tags": [],
   "languages": [
     "en",
     "zh"
   ],
   "title_zh": "红杉资本三位合伙人的 AI 论断：计算革命、长周期智能体，与 99.9% 认知工作的迁移",
-  "dek_zh": "![Sequoia's AI Thesis: A Computation Revolution, Not a Faster Internet](/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png)",
+  "dek_zh": "在最近一场红杉资本主办的 AI 峰会上，红杉的三位核心合伙人帕特·格雷迪（Pat Grady）、索尼娅·黄（Sonya Huang）与康斯坦丁·布勒（Konstantine Buhler）联合给出了他们对这一波 AI 浪潮的整体判断：这不是又一次通信革命，而是一次**计算革命**；长周期智能体已经到位，服务正在变成新的软件；最终，99.9% 的认知工作会像当年的体力劳动一样被机器接管。这篇博客整理了三位合伙人在演讲中的核心观点。",
   "source": "https://www.youtube.com/watch?v=BE2CR9YT8_k",
   "image": "/images/blog/sequoias-ai-thesis-a-computation-revolution-not-a-faster.png",
   "labels": [

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -155,7 +155,8 @@ function FilterBar({ posts, selected, onToggle, onClear }) {
 
 
 function BlogCard({ post, featured, globalCount, onClick }) {
-  const cls = ['blog-post', featured ? 'feat' : ''].filter(Boolean).join(' ');
+  const cls = ['blog-post', featured ? 'feat' : '', post.image ? 'has-cover' : '']
+    .filter(Boolean).join(' ');
   const langs = post.languages || ['en'];
   return (
     <Link
@@ -172,7 +173,7 @@ function BlogCard({ post, featured, globalCount, onClick }) {
           {globalCount > 0 && <span> · {globalCount} read{globalCount > 1 ? 's' : ''}</span>}
         </div>
       </div>
-      <div>
+      <div className="body">
         <div className="ttl">{post.title_en}</div>
         {post.dek_en && <div className="dek">{post.dek_en}</div>}
         {(post.labels?.length > 0 || post.tags?.length > 0) && (
@@ -182,6 +183,14 @@ function BlogCard({ post, featured, globalCount, onClick }) {
           </div>
         )}
       </div>
+      {post.image && (
+        <img
+          className="cover"
+          src={`${import.meta.env.BASE_URL.replace(/\/$/, '')}${post.image}`}
+          alt=""
+          loading="lazy"
+        />
+      )}
     </Link>
   );
 }

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -206,9 +206,14 @@
 /* ============== Blog ============== */
 .blog-post {
   padding: 16px 0; border-bottom: var(--dash);
-  display: grid; grid-template-columns: 100px 1fr; gap: 22px;
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 22px;
+  align-items: start;
 }
+.blog-post.has-cover { grid-template-columns: 100px 1fr 160px; }
 .blog-post.feat { padding: 20px 0 22px; grid-template-columns: 200px 1fr; }
+.blog-post.feat.has-cover { grid-template-columns: 200px 1fr 240px; }
 .blog-post .when { font-family: var(--mono); font-size: 11px; opacity: 0.85; }
 .blog-post .when .meta { opacity: 0.55; margin-top: 4px; }
 .blog-post .ttl { font-family: var(--hand); font-size: 24px; font-weight: 600; line-height: 1.1; }
@@ -216,6 +221,16 @@
 .blog-post .dek { font-size: 12.5px; line-height: 1.6; margin-top: 8px; opacity: 0.9; }
 .blog-post.feat .dek { font-size: 14px; }
 .blog-post .tags { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
+.blog-post .cover {
+  width: 100%; aspect-ratio: 16 / 10; object-fit: cover;
+  border: var(--line); display: block; background: var(--hatch);
+}
+@media (max-width: 720px) {
+  .blog-post.has-cover, .blog-post.feat.has-cover {
+    grid-template-columns: 100px 1fr;
+  }
+  .blog-post .cover { grid-column: 2; max-width: 240px; margin-top: 10px; }
+}
 
 /* Single-post body: long-form markdown rendered with react-markdown. */
 .blog-body { font-size: 15px; line-height: 1.7; }

--- a/tools/video-to-blog/pipeline.py
+++ b/tools/video-to-blog/pipeline.py
@@ -774,8 +774,11 @@ def _slugify(text: str, max_len: int = 60) -> str:
     return s.rstrip("-") or "post"
 
 
+_IMAGE_ONLY_RE = re.compile(r"^!\[[^\]]*\]\([^)]+\)\s*$")
+
+
 def _parse_blog_md(md_text: str) -> tuple[str, str]:
-    """Pull H1 title and the first non-heading paragraph (dek) from blog.md."""
+    """Pull H1 title and the first non-heading, non-image paragraph (dek)."""
     title, dek = "Untitled", ""
     for line in md_text.splitlines():
         s = line.strip()
@@ -785,9 +788,10 @@ def _parse_blog_md(md_text: str) -> tuple[str, str]:
     after_h1 = md_text.split("\n", 1)[1] if "\n" in md_text else ""
     for para in re.split(r"\n\s*\n", after_h1):
         p = para.strip()
-        if p and not p.startswith("#"):
-            dek = re.sub(r"\s+", " ", p)[:240]
-            break
+        if not p or p.startswith("#") or _IMAGE_ONLY_RE.match(p):
+            continue
+        dek = re.sub(r"\s+", " ", p)[:240]
+        break
     return title, dek
 
 


### PR DESCRIPTION
## Summary
- The Sequoia post landed with a broken \`dek_en\`/\`dek_zh\` — the literal markdown image syntax (e.g. \`![title](/images/blog/...)\`) instead of a summary line. Cause: \`pipeline._parse_blog_md\` picked the *first non-heading paragraph* as the dek, and the cover image markdown that gets inserted right after the H1 *is* the first paragraph. Fixed by also skipping paragraphs that are a single image reference.
- Repaired the Sequoia post's \`dek_en\`/\`dek_zh\` in \`meta.json\` and \`posts.json\` retroactively.
- The blog index never rendered the cover image even though every recent post carries an \`image\` field, leaving cards looking sparse. Added a 160px (240px featured) thumbnail as a third grid column on cards that have one. Posts without a cover (Lapopolo) keep the prior 2-column layout. Mobile collapses to a single column.

## Test plan
- [x] Local \`npm run dev\` — Sequoia/Ralph/Cat Woo cards show their content-aware diagrams; Lapopolo card stays text-only; filter chips and sort dropdown unchanged.
- [x] Pages deploy after merge — verify https://jianwang-ntu.github.io/blog/ matches.