### PR TITLE
deploy: include JSON in /images/ → S3 rewrite

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,15 +48,17 @@ jobs:
       - run: cp dist/index.html dist/404.html
       - run: touch dist/.nojekyll
 
-      # Rewrite /images/ refs in built HTML/JS/CSS/MD so every consumer
+      # Rewrite /images/ refs in built HTML/JS/CSS/JSON/MD so every consumer
       # loads images from the public S3 bucket rather than the deploy
       # target's local /images/ path. Match the four delimiter forms
       # ('"/images/, \"/images/, (/images/, =/images/) so we never touch
       # unrelated text. Markdown is included so blog posts written
-      # `![alt](/images/...)` resolve via the same bucket.
+      # `![alt](/images/...)` resolve via the same bucket. JSON is
+      # included so posts.json's "image": "/images/..." entries — read
+      # by the React index page — resolve via S3 too.
       - name: Rewrite /images/ → S3
         run: |
-          find dist -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.md' \) \
+          find dist -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '*.json' -o -name '*.md' \) \
             -print0 \
           | xargs -0 sed -i \
               -e "s|\"/images/|\"${S3_IMAGE_BASE}/images/|g" \


### PR DESCRIPTION
## Summary
\`posts.json\` carries \`"image": "/images/blog/<slug>.png"\` for each post; the React index page reads it directly. The deploy workflow's rewrite step ran on \`*.html / *.js / *.css / *.md\` only, so the JSON paths went out unchanged and Pages 404'd them (the deploy drops \`dist/images/\` entirely). Adding \`*.json\` to the find glob makes the existing four sed patterns convert those entries to the S3 URL too.

This was meant to ride PR #12 but GitHub's PR head pointer lagged behind the actual branch ref, so the squash-merge only included the first commit and the workflow fix didn't land.

Verified locally: \`npm run build\` then the rewrite step produces \`posts.json\` with \`"image": "https://publicsg.s3.ap-southeast-1.amazonaws.com/github.io/images/blog/<slug>.png"\` and a clean \`grep -rn '/images/' dist | grep -v amazonaws\` returns nothing.

## Test plan
- [ ] After merge, https://jianwang-ntu.github.io/blog/posts.json should show S3 URLs in every \`image\` field.
- [ ] https://jianwang-ntu.github.io/blog/ thumbs should load without console 404s.