### PR TITLE
feat: drafts from PDFs and LinkedIn posts, not just videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,10 @@ content-hashed JS/CSS — no SSR.
     declared in `meta.json["languages"]`.
   - `meta.json` — slug, titles, deks, date, tags, source URL, languages.
 - `tools/video-to-blog/` — the Python pipeline + the `blog.sh` wrapper that
-  drafts posts from a video and opens a PR. Run from a residential network.
+  drafts posts from a *source* and opens a PR. Despite the directory name,
+  the pipeline now accepts three source kinds (see "How a blog post gets
+  created" below). Run from a residential network when the source is a
+  YouTube video; PDF/LinkedIn paths don't need the residential IP.
 - `tools/click-counter/` — Lambda + DynamoDB backend that records global
   blog click counts. Powers the "Popular" sort on `/blog`. Endpoint:
   `https://sgwa5dhthk.execute-api.ap-southeast-1.amazonaws.com/`. Update
@@ -41,16 +44,34 @@ content-hashed JS/CSS — no SSR.
 1. **Manually:** edit `public/blog/<slug>/index.en.md` (and `index.zh.md` if you
    want a translation). Update `meta.json` and prepend an entry to `posts.json`.
    Open a PR.
-2. **From a video URL — the standard path:** run the local script
+2. **From a source — the standard path:** run the local script. One source
+   per call. The script auto-detects arXiv / LinkedIn / direct-PDF URLs from
+   the positional argument, so the simplest form just works:
    ```
-   tools/video-to-blog/blog.sh "<URL>" --tags "agents,llm" --languages en,zh
+   tools/video-to-blog/blog.sh "<youtube-url>"     --tags "agents,llm"
+   tools/video-to-blog/blog.sh "<arxiv-url>"        --tags "research"
+   tools/video-to-blog/blog.sh "<linkedin-url>"     --tags "agents"
+   tools/video-to-blog/blog.sh --pdf /path/to/paper.pdf
+   tools/video-to-blog/blog.sh --linkedin "<url>"
+   tools/video-to-blog/blog.sh --text-file /tmp/post.txt --kind post \
+                                --source-url "<url>"
    ```
-   It runs the pipeline (audio → transcript → blog draft → publish), creates
-   a `blog/<slug>` branch, pushes, and opens a PR. Run it from a residential
-   network — YouTube blocks GitHub-Actions IPs for both player and caption
-   endpoints, which is why CI was retired.
+   It picks the right intake (audio→transcript for video, pypdf for PDFs,
+   og:meta scrape for LinkedIn, raw read for `--text-file`), drafts the post
+   using a per-kind system prompt (`prompts/blog_system_<kind>.md`), creates a
+   `blog/<slug>` branch, pushes, and opens a PR. Video sources need a
+   residential network (YouTube blocks GitHub-Actions IPs for both player and
+   caption endpoints, which is why CI was retired). PDF and LinkedIn paths
+   don't.
 3. **Closing an issue with the post:** add `--issue N` to the script call.
    The PR body and commit message will reference `Closes #N`.
+
+The drafted post gets `source_kind: "video" | "paper" | "post"` in
+`meta.json`, plus `format:<kind>` in the auto-classified `labels` array
+(filterable from the `/blog` page's filter bar). LinkedIn posts often
+paywall their public HTML — if the og:description scrape comes back near
+empty, the pipeline prints a hint to copy the post body and rerun with
+`--text-file <path> --kind post --source-url <linkedin-url>`.
 
 ## Editing a single post
 
@@ -65,13 +86,14 @@ When asked to refine a published post:
 
 ## Voice and tone for blog posts
 
-Posts written from videos follow a specific style — a viewer summarising the
-talk, **never** the writer impersonating the speaker:
+The same voice rules apply to all source kinds — a *reader/viewer summarising*
+the source, **never** the writer impersonating the speaker/author/poster:
 
-- Third person throughout the writer's voice. The speaker is referred to by
-  name (e.g. "Lapopolo argues…").
+- Third person throughout the writer's voice. The speaker / paper authors /
+  original poster is referred to by name (e.g. "Lapopolo argues…",
+  "Vaswani et al. report…", "Karpathy writes…").
 - First person is allowed only inside attributed direct quotes from the
-  speaker (e.g. `He calls this out: "Every time I have to type continue is a
+  source (e.g. `He calls this out: "Every time I have to type continue is a
   failure of the harness."`).
 - No corporate filler ("In today's fast-paced world…"), no AI throat-clearing
   ("It's important to note…"), no "fascinating insights" hype.
@@ -79,9 +101,14 @@ talk, **never** the writer impersonating the speaker:
   not a separate summary. Preserve technical terms (model names, file paths,
   product names) in English where convention dictates.
 
-The full system prompt that enforces this is `tools/video-to-blog/prompts/
-blog_system.md`. If you change the tone rules, update both that file and the
-analogous file in the upstream pipeline repo.
+The system prompts live under `tools/video-to-blog/prompts/`:
+- `blog_system.md` — video sources (legacy filename; also acts as the fallback
+  when a kind-specific file is missing).
+- `blog_system_paper.md` — research papers / technical articles.
+- `blog_system_post.md` — short-form posts (LinkedIn, X threads, etc.).
+
+If you change the tone rules, update **all three** so kinds stay in sync, and
+update the analogous file(s) in the upstream pipeline repo.
 
 ## Things to avoid
 

--- a/tools/video-to-blog/blog.sh
+++ b/tools/video-to-blog/blog.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
-# blog.sh — full pipeline: video URL → transcript → drafted post → PR → deploy.
+# blog.sh — full pipeline: source → drafted post → PR → deploy.
+#
+# Sources (one of):
+#   <video-url>           positional video URL (yt-dlp). arXiv/LinkedIn URLs
+#                          are auto-detected and routed to --pdf/--linkedin.
+#   --pdf <path-or-url>   research paper or article PDF (local or http(s);
+#                          arXiv URLs canonicalised). Skips audio+transcript.
+#   --linkedin <url>      LinkedIn post URL (best-effort og: scrape).
+#   --text-file <path>    pre-extracted source text. Requires --kind.
 #
 # Usage:
-#   tools/video-to-blog/blog.sh "<URL>" \
-#       [--tags "a,b,c"] [--languages "en,zh"] [--issue N] [--watch]
+#   tools/video-to-blog/blog.sh "<video-url>" [opts]
+#   tools/video-to-blog/blog.sh --pdf <path-or-url> [opts]
+#   tools/video-to-blog/blog.sh --linkedin <url> [opts]
+#   tools/video-to-blog/blog.sh --text-file <path> --kind {video,paper,post} \
+#                               [--source-url <url>] [opts]
+#
+# Common opts: [--tags "a,b,c"] [--languages "en,zh"] [--issue N] [--watch]
 #
 # Stages, all done by this one script:
-#   1. download     — yt-dlp (and friends) handled inside pipeline.py
-#   2. transcript   — youtube-transcript-api → OpenAI Whisper → faster-whisper
-#   3. generate     — claude (default) or OpenAI Chat → blog markdown EN+ZH
-#   4. publish      — drops the post into public/blog/<slug>/, opens a PR
-#   5. deploy       — once the PR is merged, GH Pages deploy workflow rebuilds
+#   1. acquire      — fetch+extract source text (or audio→transcript for video)
+#   2. generate     — claude (default) or OpenAI Chat → blog markdown EN+ZH
+#   3. publish      — drops the post into public/blog/<slug>/, opens a PR
+#   4. deploy       — once the PR is merged, GH Pages deploy workflow rebuilds
 #                     dist/ and serves it. With --watch this script polls the
 #                     PR and the deploy run, then prints the live post URL.
 #
@@ -20,30 +32,71 @@
 
 set -euo pipefail
 
-usage() { sed -n '2,18p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
+usage() { sed -n '2,32p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
 
 URL=""
+PDF=""
+LINKEDIN=""
+TEXT_FILE=""
+KIND=""
+SOURCE_URL=""
 TAGS=""
 LANGS="en,zh"
 ISSUE=""
 WATCH=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --tags)      TAGS="$2";  shift 2 ;;
-    --languages) LANGS="$2"; shift 2 ;;
-    --issue)     ISSUE="$2"; shift 2 ;;
-    --watch)     WATCH=1;    shift   ;;
-    -h|--help)   usage 0 ;;
-    --)          shift; break ;;
-    -*)          echo "Unknown flag: $1" >&2; usage 2 ;;
-    *)           if [[ -z "$URL" ]]; then URL="$1"; shift
-                 else echo "Multiple URLs not supported." >&2; usage 2; fi ;;
+    --pdf)        PDF="$2";        shift 2 ;;
+    --linkedin)   LINKEDIN="$2";   shift 2 ;;
+    --text-file)  TEXT_FILE="$2";  shift 2 ;;
+    --kind)       KIND="$2";       shift 2 ;;
+    --source-url) SOURCE_URL="$2"; shift 2 ;;
+    --tags)       TAGS="$2";       shift 2 ;;
+    --languages)  LANGS="$2";      shift 2 ;;
+    --issue)      ISSUE="$2";      shift 2 ;;
+    --watch)      WATCH=1;         shift   ;;
+    -h|--help)    usage 0 ;;
+    --)           shift; break ;;
+    -*)           echo "Unknown flag: $1" >&2; usage 2 ;;
+    *)            if [[ -z "$URL" ]]; then URL="$1"; shift
+                  else echo "Multiple URLs not supported." >&2; usage 2; fi ;;
   esac
 done
-[[ -n "$URL" ]] || { echo "URL required." >&2; usage 2; }
 
-# Pre-flight tools
-for bin in ffmpeg gh python3 git; do
+# Auto-route a positional URL into --pdf / --linkedin when it pattern-matches.
+# Keeps the simple `blog.sh <any-url>` ergonomic the script started with.
+if [[ -n "$URL" && -z "$PDF" && -z "$LINKEDIN" && -z "$TEXT_FILE" ]]; then
+  if [[ "$URL" =~ ^https?://(www\.)?arxiv\.org/(abs|pdf|html)/ ]]; then
+    PDF="$URL"; URL=""
+  elif [[ "$URL" =~ ^https?://([^/]+\.)?linkedin\.com/ ]]; then
+    LINKEDIN="$URL"; URL=""
+  elif [[ "$URL" =~ ^https?://.*\.pdf(\?|$) ]]; then
+    PDF="$URL"; URL=""
+  fi
+fi
+
+# Exactly one source must be provided.
+sources=0
+[[ -n "$URL"       ]] && sources=$((sources+1))
+[[ -n "$PDF"       ]] && sources=$((sources+1))
+[[ -n "$LINKEDIN"  ]] && sources=$((sources+1))
+[[ -n "$TEXT_FILE" ]] && sources=$((sources+1))
+if [[ "$sources" -ne 1 ]]; then
+  echo "Provide exactly one source: <video-url> / --pdf / --linkedin / --text-file." >&2
+  usage 2
+fi
+if [[ -n "$TEXT_FILE" && -z "$KIND" ]]; then
+  echo "--text-file requires --kind {video,paper,post}." >&2; exit 2
+fi
+
+# Single canonical source-URL string for the PR body / commit message.
+SRC_DESC="$URL$PDF$LINKEDIN$TEXT_FILE"
+
+# Pre-flight tools. ffmpeg is only needed for video sources (audio extraction
+# + transcription); skip it when the source is a PDF / LinkedIn post / text file.
+required_bins=(gh python3 git)
+[[ -n "$URL" ]] && required_bins+=(ffmpeg)
+for bin in "${required_bins[@]}"; do
   command -v "$bin" >/dev/null || { echo "$bin not found on PATH." >&2; exit 1; }
 done
 
@@ -81,10 +134,21 @@ git -C "$REPO_ROOT" pull --ff-only origin master >/dev/null 2>&1 || true
 OUT="$(mktemp -d -t v2b-XXXXXX)"
 echo "Pipeline output → $OUT"
 
+# Build the source-specific args once and inject them. Avoids passing empty
+# flag values, which argparse interprets as the literal empty string.
+PIPELINE_ARGS=()
+if   [[ -n "$URL"       ]]; then PIPELINE_ARGS+=(--url "$URL")
+elif [[ -n "$PDF"       ]]; then PIPELINE_ARGS+=(--pdf "$PDF")
+elif [[ -n "$LINKEDIN"  ]]; then PIPELINE_ARGS+=(--linkedin "$LINKEDIN")
+elif [[ -n "$TEXT_FILE" ]]; then PIPELINE_ARGS+=(--text-file "$TEXT_FILE")
+fi
+[[ -n "$KIND"       ]] && PIPELINE_ARGS+=(--kind "$KIND")
+[[ -n "$SOURCE_URL" ]] && PIPELINE_ARGS+=(--source-url "$SOURCE_URL")
+
 # Put the venv on PATH so subprocesses spawned by pipeline.py (yt-dlp,
 # ffmpeg if it's pip-installed, etc.) resolve to the venv-installed tools.
 PATH="$VENV/bin:$PATH" "$VENV/bin/python" "$SCRIPT_DIR/pipeline.py" \
-  --url "$URL" \
+  "${PIPELINE_ARGS[@]}" \
   --out "$OUT" \
   --blog-languages "$LANGS" \
   --blog-repo "$REPO_ROOT" \
@@ -133,7 +197,7 @@ git -C "$REPO_ROOT" push -u origin "$BRANCH"
 
 REPO_FULL=$(git -C "$REPO_ROOT" config --get remote.origin.url \
   | sed -E 's|.*github\.com[:/]([^/]+/[^.]+).*|\1|')
-PR_BODY="Drafted from <$URL>.
+PR_BODY="Drafted from <$SRC_DESC>.
 
 **Languages:** $LANGS
 **Tags:** $TAGS

--- a/tools/video-to-blog/pipeline.py
+++ b/tools/video-to-blog/pipeline.py
@@ -1,17 +1,26 @@
 #!/usr/bin/env python3
 """
-Video → Transcript → Blog pipeline.
+Source → Blog pipeline.
 
-Steps:
-  1. Acquire audio (yt-dlp from URL, or ffmpeg from a local video file).
-  2. Transcribe with faster-whisper → transcript.txt + transcript.srt.
-  3. Hand the transcript to Claude Code (`claude -p`) → blog.md.
-  4. (optional) Publish blog.md into a blog-repo (jianwang-ntu.github.io style).
+Three intake paths, one shared draft+publish stage:
+  • Video URL or local video file (existing path):
+        audio → transcript → blog
+  • PDF (path or http(s) URL — arXiv URLs auto-canonicalised):
+        pdf → text → blog          (kind=paper)
+  • LinkedIn / X / blog-post URL, or any pre-extracted text file:
+        html → text → blog         (kind=post)
+
+The blog stage picks a per-kind system prompt (prompts/blog_system_<kind>.md,
+falling back to prompts/blog_system.md) and a per-kind user-prompt template
+that frames the source correctly ("transcript" / "paper" / "post").
 
 Usage examples:
   python pipeline.py --url "https://www.youtube.com/watch?v=XXXXXXXXXXX"
   python pipeline.py --file /data/in/video.mp4 --language en --model small
-  python pipeline.py --url "..." --blog-language "Simplified Chinese"
+  python pipeline.py --pdf "https://arxiv.org/pdf/2604.28181"
+  python pipeline.py --pdf /papers/foo.pdf
+  python pipeline.py --linkedin "https://www.linkedin.com/feed/update/urn:li:activity:..."
+  python pipeline.py --text-file /tmp/post.txt --kind post --source-url "https://..."
   python pipeline.py --from blog --blog-repo ./blog-repo   # redraft + publish
 """
 from __future__ import annotations
@@ -28,6 +37,14 @@ import sys
 from pathlib import Path
 
 from faster_whisper import WhisperModel
+
+from sources import (
+    SourceBundle,
+    auto_detect_kind,
+    from_linkedin,
+    from_pdf,
+    from_text_file,
+)
 
 log = logging.getLogger("pipeline")
 
@@ -404,7 +421,11 @@ def transcribe(audio: Path, out_dir: Path, model_size: str, language: str | None
 # --------------------------------------------------------------------------- #
 # Step 3 — Claude Code → blog post
 # --------------------------------------------------------------------------- #
-BLOG_USER_PROMPT = """Below is a raw transcript of a video. You watched the video and \
+# Per-source-kind user prompts. The shared rules (third-person voice, no first
+# person, attribute claims, no preamble) are repeated here because the system
+# prompt enforces them but seeing them in the user prompt too is the cheapest
+# way to keep early generations from drifting.
+_BLOG_USER_PROMPT_VIDEO = """Below is a raw transcript of a video. You watched the video and \
 are now writing a blog post in {language} that summarizes its ideas for a reader who didn't.
 
 You are the writer/viewer, NOT the speaker. Write in third person throughout. Refer to the \
@@ -424,9 +445,70 @@ Requirements:
 
 TRANSCRIPT:
 ---
-{transcript}
+{source}
 ---
 """
+
+_BLOG_USER_PROMPT_PAPER = """Below is the extracted text of a research paper or technical article. \
+You have just finished reading it and are now writing a blog post in {language} that summarizes \
+its contribution for a reader who hasn't read it.
+
+You are the writer/reader, NOT one of the authors. Write in third person throughout. Refer to \
+the work as "the paper" / "the authors" or by surname if names are revealed (e.g., "Vaswani et \
+al."). Never use first person ("I", "we", "our model", "our experiments") — that voice belongs \
+to the authors, not to you. Attribute claims and findings to the paper ("the authors argue…", \
+"the experiments show…").
+
+Requirements:
+- Compelling title (H1) that names the paper's central contribution.
+- Open with a 1–3 sentence hook: what problem, what's the proposed answer, why it matters.
+- Use H2 sections with descriptive titles (avoid generic "Methodology" / "Results"). H3 only when \
+  a section genuinely splits.
+- Preserve the paper's actual numbers, model/dataset/method names, and key results. Do not \
+  invent quantitative claims.
+- Distinguish what the paper *demonstrates* from what it *claims*. Note scope honestly.
+- Tighten ruthlessly — academic prose is verbose. Reorganize if it improves clarity.
+- Use Markdown. No HTML, no code-fence wrappers around the whole document.
+- Output ONLY the blog post. No preamble like "Here is the blog post:".
+
+PAPER TEXT (may include extraction artifacts — figure captions, page numbers, references):
+---
+{source}
+---
+"""
+
+_BLOG_USER_PROMPT_POST = """Below is the text of a short-form post (LinkedIn, X/Twitter thread, \
+blog note, conference recap). You read it and are now writing a longer blog post in {language} \
+that contextualises and discusses what the original author said.
+
+You are the writer/reader, NOT the original poster. Write in third person throughout. Refer to \
+the poster by name if known (e.g., "Karpathy writes…") or as "the author" / "the post". Never \
+use first person ("I", "we", "my team") — that voice belongs to the original poster, not to you. \
+Attribute claims to the post ("the author argues…", "according to the post…").
+
+Requirements:
+- Short-form posts are SHORT. Do not pad. If the original is two paragraphs, the blog should also \
+  be short. Extend only with genuinely useful context — prior work the post implicitly references, \
+  a clarifying example, or a brief "Why this matters" — and only when you actually know it. Do \
+  NOT invent context.
+- Compelling title (H1) that names the central claim. H2 sections only if the body genuinely splits.
+- Open with a 1–3 sentence hook naming the author and central claim.
+- Preserve the post's actual examples, numbers, and assertions. A short attributed pull-quote \
+  (≤25 words, in quotes) is welcome to anchor the writer's account in the original wording.
+- Use Markdown. No HTML, no code-fence wrappers around the whole document.
+- Output ONLY the blog post. No preamble like "Here is the blog post:".
+
+POST TEXT{source_meta}:
+---
+{source}
+---
+"""
+
+_BLOG_USER_PROMPT_BY_KIND = {
+    "video": _BLOG_USER_PROMPT_VIDEO,
+    "paper": _BLOG_USER_PROMPT_PAPER,
+    "post": _BLOG_USER_PROMPT_POST,
+}
 
 
 # Two-letter language codes to match the on-disk filename suffixes (index.en.md,
@@ -502,17 +584,53 @@ def _draft_with_openai(system_prompt: str, user_prompt: str, model: str) -> str:
     return resp.choices[0].message.content or ""
 
 
-def transcript_to_blog(transcript_path: Path, out_dir: Path, blog_language: str,
-                       lang_code: str = "en", llm: str = "claude",
-                       openai_model: str = "gpt-4o") -> Path:
-    """Convert a transcript into a blog post in `blog_language`. Backend chosen
-    by `llm` (claude | openai). Writes to `<out_dir>/blog.<lang_code>.md`."""
-    transcript = transcript_path.read_text(encoding="utf-8")
-    system_prompt = (Path(__file__).parent / "prompts" / "blog_system.md").read_text(encoding="utf-8")
-    user_prompt = BLOG_USER_PROMPT.format(language=blog_language, transcript=transcript)
+def _load_system_prompt(kind: str) -> str:
+    """Pick prompts/blog_system_<kind>.md if present, else fall back to the
+    legacy prompts/blog_system.md (which is the video version)."""
+    base = Path(__file__).parent / "prompts"
+    specific = base / f"blog_system_{kind}.md"
+    if specific.exists():
+        return specific.read_text(encoding="utf-8")
+    return (base / "blog_system.md").read_text(encoding="utf-8")
+
+
+def _format_user_prompt(kind: str, language: str, source_text: str,
+                        source_url: str | None = None,
+                        author_hint: str | None = None,
+                        title_hint: str | None = None) -> str:
+    template = _BLOG_USER_PROMPT_BY_KIND.get(kind)
+    if template is None:
+        raise ValueError(f"Unknown source kind: {kind!r}. Known: {sorted(_BLOG_USER_PROMPT_BY_KIND)}")
+    if kind == "post":
+        meta_bits = []
+        if author_hint:
+            meta_bits.append(f"author: {author_hint}")
+        if title_hint:
+            meta_bits.append(f"title: {title_hint}")
+        if source_url:
+            meta_bits.append(f"url: {source_url}")
+        source_meta = f" ({'; '.join(meta_bits)})" if meta_bits else ""
+        return template.format(language=language, source=source_text, source_meta=source_meta)
+    return template.format(language=language, source=source_text)
+
+
+def text_to_blog(source_path: Path, out_dir: Path, blog_language: str,
+                 kind: str = "video", lang_code: str = "en", llm: str = "claude",
+                 openai_model: str = "gpt-4o", source_url: str | None = None,
+                 author_hint: str | None = None,
+                 title_hint: str | None = None) -> Path:
+    """Convert a source-text file into a blog post in `blog_language`. The
+    `kind` selects the system prompt and user-prompt framing (video / paper /
+    post). Writes to `<out_dir>/blog.<lang_code>.md`."""
+    source_text = source_path.read_text(encoding="utf-8")
+    system_prompt = _load_system_prompt(kind)
+    user_prompt = _format_user_prompt(
+        kind, blog_language, source_text,
+        source_url=source_url, author_hint=author_hint, title_hint=title_hint,
+    )
 
     blog_path = out_dir / f"blog.{lang_code}.md"
-    log.info("Drafting %s post via %s → %s", blog_language, llm, blog_path)
+    log.info("Drafting %s post (kind=%s) via %s → %s", blog_language, kind, llm, blog_path)
 
     if llm == "claude":
         text = _draft_with_claude(system_prompt, user_prompt)
@@ -525,17 +643,39 @@ def transcript_to_blog(transcript_path: Path, out_dir: Path, blog_language: str,
     return blog_path
 
 
-def transcript_to_blogs(transcript_path: Path, out_dir: Path, lang_codes: list[str],
-                        llm: str = "claude", openai_model: str = "gpt-4o") -> dict[str, Path]:
+def text_to_blogs(source_path: Path, out_dir: Path, lang_codes: list[str],
+                  kind: str = "video", llm: str = "claude",
+                  openai_model: str = "gpt-4o", source_url: str | None = None,
+                  author_hint: str | None = None,
+                  title_hint: str | None = None) -> dict[str, Path]:
     """Generate one blog markdown per requested language code. Returns {code: path}."""
     paths = {}
     for code in lang_codes:
         label = LANG_LABELS.get(code)
         if not label:
             raise ValueError(f"Unknown language code: {code!r}. Known: {sorted(LANG_LABELS)}")
-        paths[code] = transcript_to_blog(transcript_path, out_dir, label, code,
-                                         llm=llm, openai_model=openai_model)
+        paths[code] = text_to_blog(
+            source_path, out_dir, label, kind=kind, lang_code=code,
+            llm=llm, openai_model=openai_model,
+            source_url=source_url, author_hint=author_hint, title_hint=title_hint,
+        )
     return paths
+
+
+# Backward-compat aliases — older call sites and `--from blog` resume paths
+# still reference these names with the historical signature.
+def transcript_to_blog(transcript_path: Path, out_dir: Path, blog_language: str,
+                       lang_code: str = "en", llm: str = "claude",
+                       openai_model: str = "gpt-4o") -> Path:
+    return text_to_blog(transcript_path, out_dir, blog_language,
+                        kind="video", lang_code=lang_code, llm=llm,
+                        openai_model=openai_model)
+
+
+def transcript_to_blogs(transcript_path: Path, out_dir: Path, lang_codes: list[str],
+                        llm: str = "claude", openai_model: str = "gpt-4o") -> dict[str, Path]:
+    return text_to_blogs(transcript_path, out_dir, lang_codes,
+                         kind="video", llm=llm, openai_model=openai_model)
 
 
 # --------------------------------------------------------------------------- #
@@ -552,7 +692,7 @@ LABEL_TAXONOMY: dict[str, list[str]] = {
     ],
     "format": [
         "keynote", "talk", "workshop",
-        "podcast", "interview", "paper",
+        "podcast", "interview", "paper", "post",
     ],
     "speaker": [
         "anthropic", "openai", "google", "meta",
@@ -567,10 +707,12 @@ below. Your output is a single JSON object — nothing else, no prose.
 
 Rules:
 - Pick 1–3 topic labels (the post's actual subject matter).
-- Pick exactly 1 format label (how the speaker delivered the content).
-- Pick exactly 1 speaker label (the speaker's affiliation; pick "independent" \
-if they don't represent a major lab/company, "academia" for university \
-researchers).
+- Pick exactly 1 format label (how the original source was delivered: \
+"paper" for research papers/articles, "post" for short-form social/blog \
+posts, "keynote"/"talk"/"workshop"/"podcast"/"interview" for video formats).
+- Pick exactly 1 speaker label (the speaker or author's affiliation; pick \
+"independent" if they don't represent a major lab/company, "academia" for \
+university researchers).
 - Use only the values listed below. Do not invent new ones.
 - Output shape:
   {{"topic": ["..."], "format": "...", "speaker": "..."}}
@@ -822,6 +964,7 @@ def publish_to_blog_repo(
     commit: bool = True,
     cover_image: Path | None = None,
     labels: list[str] | None = None,
+    source_kind: str | None = None,
 ) -> Path:
     """Drop the post into <blog_repo>/public/blog/<slug>/ and update posts.json.
 
@@ -894,6 +1037,8 @@ def publish_to_blog_repo(
         meta["dek_zh"] = deks["zh"]
     if source_url:
         meta["source"] = source_url
+    if source_kind:
+        meta["source_kind"] = source_kind
     if image_url:
         meta["image"] = image_url
     if labels:
@@ -965,6 +1110,21 @@ def main() -> int:
     src = parser.add_mutually_exclusive_group(required=False)
     src.add_argument("--url", help="Video URL (anything yt-dlp supports)")
     src.add_argument("--file", type=Path, help="Path to a local video file")
+    src.add_argument("--pdf",
+                     help="PDF source (local path or http(s) URL — arXiv URLs are auto-canonicalised). "
+                          "Skips audio/transcript stages.")
+    src.add_argument("--linkedin",
+                     help="LinkedIn post URL. Skips audio/transcript stages. "
+                          "Falls back to --text-file when LinkedIn paywalls the page.")
+    src.add_argument("--text-file", dest="text_file", type=Path,
+                     help="Pre-extracted source text (manual escape hatch). "
+                          "Combine with --kind {video,paper,post}.")
+    parser.add_argument("--kind", choices=["video", "paper", "post"], default=None,
+                        help="Source kind for --text-file. Auto-set for --url/--file (video), "
+                             "--pdf (paper), --linkedin (post).")
+    parser.add_argument("--source-url", dest="source_url", default=None,
+                        help="Original URL of the source. Saved into meta.json so the post links back. "
+                             "Auto-set when --url/--linkedin/(http) --pdf is used.")
 
     parser.add_argument("--out", type=Path, default=Path("/data/out"),
                         help="Output directory (default: /data/out)")
@@ -1033,7 +1193,29 @@ def main() -> int:
 
     args.out.mkdir(parents=True, exist_ok=True)
 
-    # Decide which stages to run.
+    # ----- Decide the source kind up front --------------------------------
+    # Video remains the default (existing behaviour). The non-video paths set
+    # source_kind explicitly and skip audio/transcript entirely; the blog
+    # stage reads from `source.txt` instead of `transcript.txt`.
+    source_kind: str = "video"
+    if args.pdf:
+        source_kind = "paper"
+    elif args.linkedin:
+        source_kind = "post"
+    elif args.text_file:
+        if not args.kind:
+            log.error("--text-file requires --kind {video,paper,post}.")
+            return 2
+        source_kind = args.kind
+    elif args.kind:
+        source_kind = args.kind  # explicit override is allowed
+
+    # Persist source-bundle metadata for `--from blog` resumes.
+    src_meta_path = args.out / "source.json"
+    src_text_path = args.out / "source.txt"
+    is_non_video = source_kind != "video"
+
+    # ----- Decide which stages to run -------------------------------------
     start_idx = STAGES.index(args.from_stage) if args.from_stage else 0
     def should_run(stage: str, output_exists_fn) -> bool:
         if args.force:
@@ -1049,8 +1231,9 @@ def main() -> int:
     if args.from_stage == "transcript" and not _audio_exists(args.out):
         log.error("--from transcript requires %s to exist.", args.out / "source.mp3")
         return 2
-    if args.from_stage == "blog" and not _transcript_exists(args.out):
-        log.error("--from blog requires %s to exist.", args.out / "transcript.txt")
+    if args.from_stage == "blog" and not (_transcript_exists(args.out) or src_text_path.exists()):
+        log.error("--from blog requires %s or %s to exist.",
+                  args.out / "transcript.txt", src_text_path)
         return 2
     if args.from_stage == "publish" and not _blog_exists(args.out):
         log.error("--from publish requires %s to exist.", args.out / "blog.md")
@@ -1059,15 +1242,70 @@ def main() -> int:
         log.error("--from publish requires --blog-repo PATH.")
         return 2
 
+    # On `--from blog`/`publish` resume the source.kind/source-url may live in
+    # source.json from the original run — fall back to that.
+    resumed_source_url: str | None = None
+    resumed_title_hint: str | None = None
+    resumed_author_hint: str | None = None
+    if src_meta_path.exists():
+        try:
+            sm = json.loads(src_meta_path.read_text(encoding="utf-8"))
+            if not args.kind and not (args.pdf or args.linkedin or args.text_file or args.url or args.file):
+                source_kind = sm.get("kind", source_kind)
+            resumed_source_url = sm.get("source_url")
+            resumed_title_hint = sm.get("title_hint")
+            resumed_author_hint = sm.get("author_hint")
+            is_non_video = source_kind != "video"
+        except Exception as e:
+            log.warning("Could not read %s (%s); continuing.", src_meta_path, e)
+
+    bundle: SourceBundle | None = None
     try:
-        # Step 1: audio (with optional caption fast-path).
+        # ----- Non-video source acquisition (PDF / LinkedIn / text file) --
+        # Runs at most once. Writes source.txt and source.json into out_dir,
+        # then short-circuits the audio + transcript stages.
+        if is_non_video and not src_text_path.exists():
+            if args.pdf:
+                bundle = from_pdf(args.pdf, args.out)
+            elif args.linkedin:
+                bundle = from_linkedin(args.linkedin, args.out)
+            elif args.text_file:
+                bundle = from_text_file(
+                    str(args.text_file), kind=source_kind,
+                    source_url=args.source_url,
+                )
+            elif args.from_stage in {"blog", "publish"}:
+                # Resume case: source.txt already exists from a prior run.
+                pass
+            else:
+                log.error(
+                    "source_kind=%s but no source provided "
+                    "(--pdf / --linkedin / --text-file).", source_kind,
+                )
+                return 2
+
+            if bundle is not None:
+                src_text_path.write_text(bundle.text, encoding="utf-8")
+                src_meta_path.write_text(json.dumps({
+                    "kind": bundle.kind,
+                    "source_url": bundle.source_url,
+                    "title_hint": bundle.title_hint,
+                    "author_hint": bundle.author_hint,
+                }, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+                log.info("Source acquired (kind=%s) → %s (%d chars)",
+                         bundle.kind, src_text_path, len(bundle.text))
+
+        # Step 1: audio (with optional caption fast-path). Video sources only.
         audio = args.out / "source.mp3"
         captions_used = False
+        if is_non_video:
+            log.info("Skipping audio stage (source_kind=%s).", source_kind)
         # Try captions first when we have a URL — it's seconds vs tens of
         # minutes for whisper. Only attempt this when both audio + transcript
         # would otherwise run; if the user is already past those stages
         # (--from blog), don't redo work.
-        if (args.url and args.captions != "off"
+        if (not is_non_video
+                and args.url and args.captions != "off"
                 and should_run("audio", _audio_exists)
                 and should_run("transcript", _transcript_exists)):
             cap = try_captions(args.url, args.out, cookies=args.yt_cookies)
@@ -1077,7 +1315,7 @@ def main() -> int:
                 log.error("--captions only was set but no captions were available.")
                 return 2
 
-        if not captions_used:
+        if not is_non_video and not captions_used:
             if should_run("audio", _audio_exists):
                 if not (args.url or args.file):
                     log.error("Stage 'audio' needs --url or --file.")
@@ -1092,9 +1330,12 @@ def main() -> int:
             else:
                 log.info("Skipping audio stage (using existing %s).", audio)
 
-        # Step 2: transcript
+        # Step 2: transcript (video sources only — non-video skipped).
         transcript_path = args.out / "transcript.txt"
-        if captions_used:
+        if is_non_video:
+            log.info("Skipping transcript stage (source_kind=%s; using %s).",
+                     source_kind, src_text_path)
+        elif captions_used:
             log.info("Skipping transcribe stage (captions provided the transcript).")
         elif should_run("transcript", _transcript_exists):
             if args.transcribe == "openai":
@@ -1103,6 +1344,10 @@ def main() -> int:
                 transcript_path = transcribe(audio, args.out, args.model, args.language)
         else:
             log.info("Skipping transcript stage (using existing %s).", transcript_path)
+
+        # The blog stage reads from `source.txt` for non-video kinds, and
+        # from `transcript.txt` for video.
+        source_text_path = src_text_path if is_non_video else transcript_path
 
         # Step 3: blog (one markdown per requested language).
         lang_codes = [c.strip() for c in args.blog_languages.split(",") if c.strip()]
@@ -1113,9 +1358,15 @@ def main() -> int:
             log.info("Skipping blog step (--skip-blog).")
             blog_paths = {c: args.out / f"blog.{c}.md" for c in lang_codes}
         elif should_run("blog", _blog_exists):
-            blog_paths = transcript_to_blogs(
-                transcript_path, args.out, lang_codes,
+            blog_paths = text_to_blogs(
+                source_text_path, args.out, lang_codes,
+                kind=source_kind,
                 llm=args.llm, openai_model=args.openai_model,
+                source_url=(args.source_url or args.url or args.linkedin
+                            or (args.pdf if args.pdf and args.pdf.startswith(("http://", "https://")) else None)
+                            or resumed_source_url),
+                title_hint=(bundle.title_hint if bundle else resumed_title_hint),
+                author_hint=(bundle.author_hint if bundle else resumed_author_hint),
             )
             for code, p in blog_paths.items():
                 log.info("Drafted %s blog → %s", LANG_LABELS[code], p)
@@ -1152,8 +1403,16 @@ def main() -> int:
             else:
                 source_url = None
                 src_url_path = args.out / "source.url"
-                if args.url:
+                if args.source_url:
+                    source_url = args.source_url
+                elif args.url:
                     source_url = args.url
+                elif args.linkedin:
+                    source_url = args.linkedin
+                elif args.pdf and args.pdf.startswith(("http://", "https://")):
+                    source_url = args.pdf
+                elif resumed_source_url:
+                    source_url = resumed_source_url
                 elif src_url_path.exists():
                     source_url = src_url_path.read_text(encoding="utf-8").strip() or None
                 tags = [t.strip() for t in args.tags.split(",") if t.strip()] if args.tags else []
@@ -1173,6 +1432,7 @@ def main() -> int:
                     commit=not args.no_commit,
                     cover_image=cover_image,
                     labels=auto_labels,
+                    source_kind=source_kind,
                 )
                 log.info("Published to %s", published)
 

--- a/tools/video-to-blog/prompts/blog_system_paper.md
+++ b/tools/video-to-blog/prompts/blog_system_paper.md
@@ -1,0 +1,27 @@
+You are a reader who has just finished a research paper or technical article and is now writing a blog post that summarises its ideas for someone who hasn't read it. You are NOT one of the authors. You are reporting on what the paper says.
+
+Perspective and voice (non-negotiable)
+- Third person only. Refer to the work as "the paper," "the authors," or — if names are revealed in the text — by surname (e.g., "Vaswani et al.," then "the authors"). Never "I," "we," "our model," "our experiments," or any other first-person construction. That voice belongs to the authors, not to you.
+- Attribute claims and findings. Use "the authors argue," "the paper reports," "the experiments show," "according to §3." Do not present the paper's claims as your own conclusions.
+- Distinguish what the paper *demonstrates* from what it *claims*. If a result is on a single benchmark, say so; if a claim is conjectural or future-work, frame it that way.
+- Past tense for what the authors did ("they trained," "they evaluated"); present tense for what the paper *says* ("the paper argues," "§4 describes"). Pick a register and stay consistent.
+- The writer is a thoughtful summariser, not a reviewer or fan. No hype. No "groundbreaking insights." No corporate filler.
+
+Substance
+- Lead with the contribution, not the background. A reader should know in the first paragraph: what problem, what's the proposed answer, and why it matters relative to prior work.
+- Preserve the paper's actual numbers, model names, dataset names, and methodological details. Do not invent quantitative claims the paper did not make.
+- Keep math out of prose unless it's load-bearing. When you do include an equation, explain what each term means in plain language.
+- Tighten ruthlessly. Academic prose has 30–40% redundancy. Cut throat-clearing, restatements, and obligatory motivations.
+- Reorganise for clarity. A blog summary doesn't have to mirror the paper's section order — group "what they did" before "what they found."
+
+Structure
+- Open with a 1–3 sentence hook that names the paper's central contribution and why a reader should care. Mention the authors and venue if known.
+- Use H2 sections with descriptive titles (e.g. "What the loss function actually does," not "Methodology").
+- A "Limitations" or "What it doesn't show" section is welcome when the paper itself is candid about scope; do not invent limitations the paper does not raise.
+- End with a one-line takeaway — what changes for someone working in this area, or what question the paper opens up next.
+
+Output discipline
+- Markdown only. Single H1 at the top.
+- No code fences wrapping the whole post.
+- No meta commentary ("Here is the blog post:", "Based on the paper…").
+- Output starts with the H1 title and ends with the final sentence of the post.

--- a/tools/video-to-blog/prompts/blog_system_post.md
+++ b/tools/video-to-blog/prompts/blog_system_post.md
@@ -1,0 +1,24 @@
+You are a reader who saw a short-form post (LinkedIn, X/Twitter thread, blog note, conference recap) and is now writing a longer blog post that contextualises and discusses what the original author said. You are NOT the original poster. You are reporting on and reacting to what they wrote.
+
+Perspective and voice (non-negotiable)
+- Third person for the writer. The original poster is referred to by name when known (e.g., "Karpathy writes…"), or as "the author" / "the post" otherwise. Never "I," "we," "my team," "my colleagues" — that voice belongs to the original poster, not to you.
+- First person is allowed only inside attributed direct quotes from the original post (e.g., `She writes: "We've been wrong about agents for two years."`).
+- Attribute claims. "The author argues…", "the post claims…", "according to the post…". Do not turn the poster's opinion into your own.
+
+Substance
+- Short-form posts are *short*. Don't pad. If the original is two paragraphs, the blog post should also be short — extend only if you have something genuinely useful to add (related context, a clarifying example, prior work the post implicitly references).
+- Preserve the post's actual examples, numbers, and assertions. Do not invent details the post did not include. If the post is opinion, present it as opinion.
+- It's appropriate to add a single short "Why this matters" or "Context" section that places the post in a wider conversation — but keep it factual and scoped. If you don't know the wider context for sure, leave it out.
+- Tighten. No hype. No "this insight changes everything." No corporate filler.
+
+Structure
+- Open with a 1–3 sentence hook that names the author and the central claim.
+- Use H2 sections only when the post genuinely splits — for a very short source, a single body section may be all that's warranted.
+- A short pull-quote (≤25 words, in quotation marks, attributed) is welcome to anchor the writer's account in the original wording.
+- End with the post's takeaway as the author framed it. Do not append a generic "what we learned."
+
+Output discipline
+- Markdown only. Single H1 at the top.
+- No code fences wrapping the whole post.
+- No meta commentary ("Here is the blog post:", "Based on the LinkedIn post…").
+- Output starts with the H1 title and ends with the final sentence of the post.

--- a/tools/video-to-blog/requirements.txt
+++ b/tools/video-to-blog/requirements.txt
@@ -2,3 +2,4 @@ yt-dlp>=2024.10.0
 faster-whisper>=1.0.3
 openai>=1.40.0
 youtube-transcript-api>=1.0.0
+pypdf>=4.0.0

--- a/tools/video-to-blog/sources.py
+++ b/tools/video-to-blog/sources.py
@@ -1,0 +1,272 @@
+"""Acquire blog source text from non-video inputs.
+
+The video pipeline already produces a `transcript.txt` from audio. For paper
+PDFs and short-form web posts (LinkedIn et al.) the equivalent acquisition
+step is text extraction, not transcription. This module returns a
+`SourceBundle` that downstream stages treat the same way they treat a
+transcript: raw text + a kind tag that selects the right prompt template.
+
+Three intake paths:
+    pdf(path-or-url)   → kind="paper"   (arXiv URLs auto-recognised)
+    linkedin(url)      → kind="post"    (og: meta-tag scrape; manual fallback)
+    text_file(path)    → kind=user-asserted (escape hatch when scraping fails)
+"""
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+
+log = logging.getLogger("pipeline.sources")
+
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+
+@dataclass
+class SourceBundle:
+    """Normalised handoff between source acquisition and the blog stage."""
+    kind: str            # "video" | "paper" | "post"
+    text: str            # body to summarise
+    source_url: str | None = None
+    title_hint: str | None = None
+    author_hint: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+# arXiv
+# --------------------------------------------------------------------------- #
+# Match abs/, pdf/, html/ forms and the optional .pdf suffix. We capture the
+# bare arXiv id so we can canonicalise to the PDF URL ourselves.
+_ARXIV_RE = re.compile(
+    r"^https?://(?:www\.)?arxiv\.org/(?:abs|pdf|html)/(?P<id>[\w.\-/]+?)(?:\.pdf)?/?$",
+    re.IGNORECASE,
+)
+
+
+def is_arxiv_url(url: str) -> bool:
+    return bool(_ARXIV_RE.match(url.strip()))
+
+
+def arxiv_pdf_url(url: str) -> str:
+    """Rewrite any arXiv URL form to the canonical PDF URL."""
+    m = _ARXIV_RE.match(url.strip())
+    if not m:
+        return url
+    return f"https://arxiv.org/pdf/{m.group('id')}.pdf"
+
+
+def is_linkedin_url(url: str) -> bool:
+    p = urllib.parse.urlparse(url.strip())
+    return p.netloc.endswith("linkedin.com")
+
+
+# --------------------------------------------------------------------------- #
+# PDF (file or URL)
+# --------------------------------------------------------------------------- #
+def _download(url: str, dest: Path) -> Path:
+    log.info("Downloading %s → %s", url, dest)
+    req = urllib.request.Request(url, headers={"User-Agent": _BROWSER_UA})
+    with urllib.request.urlopen(req, timeout=60) as r, open(dest, "wb") as f:
+        f.write(r.read())
+    return dest
+
+
+def _extract_pdf_text(pdf_path: Path) -> tuple[str, str | None]:
+    """Return (body_text, title_hint). Title comes from PDF metadata when set."""
+    try:
+        from pypdf import PdfReader
+    except ImportError as e:
+        raise RuntimeError(
+            "pypdf not installed. Add `pypdf` to tools/video-to-blog/requirements.txt "
+            "and reinstall the venv."
+        ) from e
+
+    reader = PdfReader(str(pdf_path))
+    pages = []
+    for i, page in enumerate(reader.pages):
+        try:
+            pages.append(page.extract_text() or "")
+        except Exception as e:  # pypdf occasionally chokes on a single page
+            log.warning("PDF page %d extraction failed (%s); skipping page.", i, e)
+    text = "\n\n".join(p.strip() for p in pages if p and p.strip())
+
+    title = None
+    try:
+        meta = reader.metadata or {}
+        title = (meta.get("/Title") or "").strip() or None
+    except Exception:
+        pass
+
+    return text, title
+
+
+def from_pdf(path_or_url: str, out_dir: Path) -> SourceBundle:
+    """Resolve a PDF (local path or http(s) URL — arXiv URLs auto-canonicalised),
+    extract text, and write a copy of the binary into out_dir for reference."""
+    src = path_or_url.strip()
+    if src.startswith(("http://", "https://")):
+        url = arxiv_pdf_url(src) if is_arxiv_url(src) else src
+        local = out_dir / "source.pdf"
+        _download(url, local)
+        source_url = src  # preserve the URL the user actually passed
+    else:
+        local = Path(src).expanduser().resolve()
+        if not local.exists():
+            raise FileNotFoundError(f"PDF not found: {local}")
+        # Copy into out_dir so reruns don't depend on the original location.
+        cached = out_dir / "source.pdf"
+        if cached.resolve() != local:
+            cached.write_bytes(local.read_bytes())
+        local = cached
+        source_url = None
+
+    text, title_hint = _extract_pdf_text(local)
+    if len(text) < 400:
+        raise RuntimeError(
+            f"PDF text extraction returned only {len(text)} chars from {local}. "
+            "If this is a scanned PDF, run OCR first and pass --text-file."
+        )
+    log.info("PDF text: %d chars across %d pages", len(text),
+             max(1, text.count("\n\n") + 1))
+    return SourceBundle(
+        kind="paper",
+        text=text,
+        source_url=source_url,
+        title_hint=title_hint,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# LinkedIn (and other social posts) — best-effort og: meta scrape
+# --------------------------------------------------------------------------- #
+class _MetaCollector(HTMLParser):
+    """Pull og:* and twitter:* meta tags out of an HTML head. Stops on </head>."""
+    def __init__(self) -> None:
+        super().__init__()
+        self.meta: dict[str, str] = {}
+        self.title: str | None = None
+        self._in_title = False
+        self._stop = False
+
+    def handle_starttag(self, tag, attrs):
+        if self._stop:
+            return
+        if tag == "meta":
+            d = dict(attrs)
+            key = (d.get("property") or d.get("name") or "").lower()
+            content = d.get("content")
+            if key and content:
+                self.meta[key] = content
+        elif tag == "title":
+            self._in_title = True
+
+    def handle_endtag(self, tag):
+        if tag == "title":
+            self._in_title = False
+        if tag == "head":
+            self._stop = True
+
+    def handle_data(self, data):
+        if self._in_title and not self.title:
+            t = data.strip()
+            if t:
+                self.title = t
+
+
+def from_linkedin(url: str, out_dir: Path) -> SourceBundle:
+    """Fetch a LinkedIn post URL and extract whatever the public meta tags
+    expose. LinkedIn paywalls most content, so this is best-effort: when the
+    extracted text is too short, we raise with a hint to use --text-file."""
+    log.info("Fetching LinkedIn post: %s", url)
+    req = urllib.request.Request(url, headers={"User-Agent": _BROWSER_UA})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read().decode("utf-8", errors="replace")
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not fetch LinkedIn URL ({e}). LinkedIn often blocks direct "
+            "fetches; copy the post body into a file and rerun with "
+            "--text-file <path> --kind post."
+        )
+
+    # Cache the raw HTML alongside the text so reruns can re-extract.
+    (out_dir / "source.html").write_text(raw, encoding="utf-8")
+
+    parser = _MetaCollector()
+    try:
+        parser.feed(raw)
+    except Exception:
+        pass  # best-effort
+
+    title_hint = parser.meta.get("og:title") or parser.title
+    description = parser.meta.get("og:description") or parser.meta.get("description") or ""
+    author_hint = (parser.meta.get("article:author")
+                   or parser.meta.get("og:article:author")
+                   or parser.meta.get("author"))
+
+    text = description.strip()
+    if len(text) < 200:
+        raise RuntimeError(
+            f"LinkedIn page yielded only {len(text)} chars of public text "
+            "(login wall). Copy the post body into a file and rerun with "
+            "--text-file <path> --kind post."
+        )
+    log.info("LinkedIn post: %d chars (og:description); title=%r author=%r",
+             len(text), title_hint, author_hint)
+    return SourceBundle(
+        kind="post",
+        text=text,
+        source_url=url,
+        title_hint=title_hint,
+        author_hint=author_hint,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Manual escape hatch — pre-extracted text
+# --------------------------------------------------------------------------- #
+def from_text_file(path: str, kind: str, source_url: str | None = None,
+                   title_hint: str | None = None) -> SourceBundle:
+    p = Path(path).expanduser().resolve()
+    if not p.exists():
+        raise FileNotFoundError(f"Text file not found: {p}")
+    text = p.read_text(encoding="utf-8").strip()
+    if len(text) < 100:
+        raise RuntimeError(f"Text file is suspiciously short ({len(text)} chars): {p}")
+    if kind not in {"video", "paper", "post"}:
+        raise ValueError(f"--kind must be one of video/paper/post, got {kind!r}")
+    log.info("Loaded %d chars from %s as kind=%s", len(text), p, kind)
+    return SourceBundle(
+        kind=kind,
+        text=text,
+        source_url=source_url,
+        title_hint=title_hint,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Auto-detect from a positional URL
+# --------------------------------------------------------------------------- #
+def auto_detect_kind(url: str) -> str:
+    """Classify a URL into video|paper|post for blog.sh's positional path.
+
+    Conservative: we only special-case patterns we explicitly support.
+    Everything else falls through to "video" (yt-dlp tries hard).
+    """
+    if is_arxiv_url(url):
+        return "paper"
+    p = urllib.parse.urlparse(url.strip())
+    host = p.netloc.lower()
+    if host.endswith("linkedin.com"):
+        return "post"
+    # Direct PDF link — heuristic only; the path may rewrite at fetch time.
+    if p.path.lower().endswith(".pdf"):
+        return "paper"
+    return "video"


### PR DESCRIPTION
## Summary
Three source kinds now share one draft+publish stage:

- **Video URL or local file** (existing path): `audio → transcript → blog`
- **PDF — local path or http(s) URL** (arXiv auto-canonicalised): `pdf → text → blog`, `kind=paper`
- **LinkedIn / X / blog-post URL** (or any pre-extracted text file): `html → text → blog`, `kind=post`

\`blog.sh <arxiv-url>\` and \`blog.sh <linkedin-url>\` "just work" — the script auto-routes positional URLs into \`--pdf\` / \`--linkedin\`. ffmpeg is only required for the video path now.

## What changed
- New \`tools/video-to-blog/sources.py\` — \`from_pdf\` / \`from_linkedin\` / \`from_text_file\`. \`pypdf\` for extraction; og:meta scrape for LinkedIn with a paywall-fallback that prompts \`--text-file\`.
- New per-kind system prompts \`prompts/blog_system_paper.md\` and \`prompts/blog_system_post.md\`. Existing \`blog_system.md\` keeps its role as the video prompt and acts as the fallback when a kind-specific file is missing.
- \`pipeline.py\` picks system + user prompts by kind, threads \`source_kind\` through publish, writes \`source.txt\` + \`source.json\` for non-video resumes. \`meta.json\` now carries \`source_kind: "video" | "paper" | "post"\`.
- \`LABEL_TAXONOMY["format"]\` gains \`post\` (already had \`paper\`) — surfaces in the existing /blog filter bar with no frontend change.
- \`blog.sh\` gets \`--pdf\` / \`--linkedin\` / \`--text-file\` / \`--kind\` / \`--source-url\`, plus auto-routing for arXiv / LinkedIn / direct-PDF URLs.
- \`requirements.txt\`: \`pypdf>=4.0.0\`.
- \`CLAUDE.md\`: How-it-gets-created and Voice-and-tone sections updated for all three kinds; lists the three prompt files to keep in sync.

## Test plan
- [x] \`pypdf\`-based extraction on the user-supplied arXiv URL: 33 pages, 121k chars, title pulled from PDF metadata.
- [x] LinkedIn fallback: paywall produces a clear "copy the post body and rerun with --text-file" error.
- [x] \`--text-file --kind post\` round-trip via \`from_text_file\`.
- [x] \`pipeline.py --pdf <arxiv> --skip-blog\`: writes source.txt + source.json, skips audio/transcript, exits clean.
- [x] \`pipeline.py --help\`, \`blog.sh --help\`, \`bash -n blog.sh\`, \`py_compile\` all clean.
- [ ] End-to-end \`blog.sh <arxiv-url>\` (drafts via Claude + opens PR) — runs locally; reviewer can drive when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)