### PR TITLE
feat: issue-driven blog drafting — generalised form + watch-issues poller

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog-request.yml
+++ b/.github/ISSUE_TEMPLATE/blog-request.yml
@@ -1,0 +1,69 @@
+name: Blog draft request
+description: Drop a video / paper / blog / LinkedIn URL — the watcher drafts a post and opens a PR.
+title: "[blog] "
+labels: ["blog-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill in the source. The watcher (`tools/video-to-blog/watch-issues.sh`)
+        polls open `blog-request` issues and runs the pipeline end-to-end.
+        On success a PR is opened with `Closes #N` so the issue closes when
+        the PR merges.
+
+  - type: input
+    id: source_url
+    attributes:
+      label: Source URL
+      description: Any URL the pipeline understands — YouTube, arXiv, LinkedIn, direct PDF, blog post, etc.
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source_kind
+    attributes:
+      label: Source kind
+      description: Leave on `auto` to let the URL pattern decide (arXiv → paper, LinkedIn → post, otherwise video). Override only when the URL doesn't pattern-match.
+      options:
+        - auto
+        - video
+        - paper
+        - post
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags
+      description: Comma-separated free-form tags. The auto-classifier adds its own structured `topic:` / `format:` / `speaker:` labels regardless.
+      placeholder: agents,llm
+
+  - type: dropdown
+    id: languages
+    attributes:
+      label: Languages
+      description: Translations to produce. English is always written.
+      options:
+        - en,zh
+        - en
+      default: 0
+
+  - type: textarea
+    id: pasted_source
+    attributes:
+      label: Pasted source body
+      description: |
+        Paste the source text here only when the URL is paywalled (LinkedIn login
+        wall, member-only post, etc). If filled, the pipeline uses `--text-file`
+        with this content and stores the URL above as the post's `source` link.
+        Leave empty otherwise.
+      render: text
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Anything the writer should know — preferred angle, topic context, must-mention examples.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,24 @@ content-hashed JS/CSS — no SSR.
    don't.
 3. **Closing an issue with the post:** add `--issue N` to the script call.
    The PR body and commit message will reference `Closes #N`.
+4. **Issue-driven (`watch-issues.sh`):** file an issue using the
+   `Blog draft request` form (`.github/ISSUE_TEMPLATE/blog-request.yml`,
+   auto-applies the `blog-request` label) with a Source URL — YouTube /
+   arXiv / LinkedIn / direct PDF / blog post URL — plus optional tags,
+   languages, and a `Pasted source body` for paywalled inputs. Then run:
+   ```
+   tools/video-to-blog/watch-issues.sh         # default poll interval 60s
+   WATCH_INTERVAL=30 tools/video-to-blog/watch-issues.sh
+   tools/video-to-blog/watch-issues.sh --once  # drain a single issue and exit
+   ```
+   The poller picks the oldest unassigned issue, claims it (assigns to
+   yourself so a parallel watcher won't double-process), parses the form
+   body into `--pdf`/`--linkedin`/positional URL or `--text-file --kind …`,
+   then invokes `blog.sh` with `--issue N`. The PR's `Closes #N` closes
+   the issue on merge. On failure the watcher comments the error and
+   un-assigns so the next tick retries. Best run on a residential box
+   (cron or systemd-unit) — YouTube blocks GitHub-Actions ranges, and
+   the same machine should hold the gh / claude / aws creds.
 
 The drafted post gets `source_kind: "video" | "paper" | "post"` in
 `meta.json`, plus `format:<kind>` in the auto-classified `labels` array

--- a/tools/video-to-blog/watch-issues.sh
+++ b/tools/video-to-blog/watch-issues.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# watch-issues.sh — poll GitHub issues and draft blog posts from them locally.
+#
+# Loops every $WATCH_INTERVAL seconds (default 60). On each tick:
+#   1. Find one open, unassigned issue labeled `blog-request` (or `video-blog`
+#      for legacy issues).
+#   2. Claim it by assigning to ourselves so a second watcher won't double-process.
+#   3. Parse the issue-form body into URL / kind / tags / languages / pasted text.
+#   4. Run blog.sh with the right arguments. The PR body's `Closes #N` will close
+#      the issue automatically when the PR is merged.
+#   5. On failure, comment with the error and unassign so the issue is retryable.
+#
+# Usage:
+#   tools/video-to-blog/watch-issues.sh
+#   WATCH_INTERVAL=30 tools/video-to-blog/watch-issues.sh
+#   tools/video-to-blog/watch-issues.sh --once   # single pass for testing
+#
+# Why local instead of CI: drafting from a video URL needs a residential IP
+# (YouTube blocks GitHub-Actions ranges for both player + caption endpoints).
+# This script is what you'd cron / systemd-unit on a residential box.
+
+set -euo pipefail
+
+usage() { sed -n '2,21p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
+
+ONCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once)    ONCE=1; shift ;;
+    -h|--help) usage 0 ;;
+    *)         echo "Unknown flag: $1" >&2; usage 2 ;;
+  esac
+done
+
+INTERVAL="${WATCH_INTERVAL:-60}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_FULL=$(git -C "$REPO_ROOT" config --get remote.origin.url \
+  | sed -E 's|.*github\.com[:/]([^/]+/[^.]+).*|\1|')
+
+# Pre-flight: gh logged in, blog.sh executable, claude on PATH (drafting fails
+# fast if claude is missing, but better to surface early than mid-run).
+command -v gh >/dev/null || { echo "gh not on PATH." >&2; exit 1; }
+[[ -x "$SCRIPT_DIR/blog.sh" ]] || { echo "blog.sh missing or not executable." >&2; exit 1; }
+ME=$(gh api user --jq .login 2>/dev/null) || { echo "gh not authenticated. Run: gh auth login" >&2; exit 1; }
+
+# Auto-load secrets (ANTHROPIC_API_KEY / OPENAI_API_KEY) the same way blog.sh does
+# so we can fail fast if they're missing rather than partway through a draft.
+[[ -f "$REPO_ROOT/.env" ]] && { set -a; . "$REPO_ROOT/.env"; set +a; }
+
+echo "watch-issues: $REPO_FULL  interval=${INTERVAL}s  user=$ME"
+[[ "$ONCE" -eq 1 ]] && echo "  (single-pass mode)"
+
+# Parse the issue-form body. Each section is `### Header\n\nbody...` until the
+# next `### ` or EOF. `_No response_` becomes empty. We support both the new
+# "Source URL" / "Source kind" headers and the legacy "Video URL" header so the
+# watcher works against issues filed before the source-diversity expansion.
+parse_issue() {
+  python3 - <<'PY'
+import json, re, sys
+body = sys.stdin.read()
+fields = {}
+for s in re.split(r"^### ", body, flags=re.M)[1:]:
+    head, *rest = s.split("\n", 1)
+    val = (rest[0] if rest else "").rstrip()
+    val = val.lstrip("\n")
+    if val.strip() == "_No response_":
+        val = ""
+    fields[head.strip().lower()] = val
+url   = (fields.get("source url") or fields.get("video url") or "").strip()
+kind  = (fields.get("source kind") or "auto").strip().lower()
+tags  = fields.get("tags", "").strip()
+langs = (fields.get("languages") or "en,zh").strip()
+text  = fields.get("pasted source body", "")
+print(json.dumps({
+    "url": url, "kind": kind, "tags": tags, "langs": langs, "text": text,
+}))
+PY
+}
+
+# One iteration: returns 0 if it processed an issue, 1 if there was nothing
+# to do, 2 if processing failed.
+process_one() {
+  # Pick the oldest unassigned open issue. Sorting by `created` keeps FIFO order
+  # so people whose issues sit longest get drafted first.
+  local raw
+  raw=$(gh issue list --repo "$REPO_FULL" \
+        --label blog-request --state open --search 'no:assignee sort:created-asc' \
+        --json number,title,body --limit 1)
+  if [[ "$raw" == "[]" || -z "$raw" ]]; then
+    # Fall back to legacy label so a half-migrated issue tracker still works.
+    raw=$(gh issue list --repo "$REPO_FULL" \
+          --label video-blog --state open --search 'no:assignee sort:created-asc' \
+          --json number,title,body --limit 1)
+  fi
+  if [[ "$raw" == "[]" || -z "$raw" ]]; then
+    return 1
+  fi
+
+  local n title body
+  n=$(jq -r '.[0].number'    <<<"$raw")
+  title=$(jq -r '.[0].title' <<<"$raw")
+  body=$(jq -r '.[0].body'   <<<"$raw")
+  echo "→ #$n  $title"
+
+  # Claim. If the assign call fails (e.g. someone else just took it) skip and
+  # let the next tick find the next open issue.
+  if ! gh issue edit "$n" --repo "$REPO_FULL" --add-assignee "$ME" >/dev/null 2>&1; then
+    echo "  could not claim #$n; skipping"
+    return 1
+  fi
+
+  # Parse the form body into shell vars.
+  local fields URL KIND TAGS LANGS TEXT
+  fields=$(printf '%s' "$body" | parse_issue) || {
+    gh issue comment "$n" --repo "$REPO_FULL" \
+      --body "Watcher could not parse this issue's body. Please reformat using the issue template, then unassign me." >/dev/null
+    return 2
+  }
+  URL=$(jq -r '.url'   <<<"$fields")
+  KIND=$(jq -r '.kind' <<<"$fields")
+  TAGS=$(jq -r '.tags' <<<"$fields")
+  LANGS=$(jq -r '.langs'<<<"$fields")
+  TEXT=$(jq -r '.text' <<<"$fields")
+
+  if [[ -z "$URL" && -z "$TEXT" ]]; then
+    gh issue comment "$n" --repo "$REPO_FULL" \
+      --body "Watcher couldn't find a Source URL or Pasted source body. Add one and unassign me." >/dev/null
+    gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null
+    return 2
+  fi
+
+  # Build blog.sh arguments. Pasted source wins over URL (for paywalled posts).
+  local -a args=()
+  local cleanup_text=""
+  if [[ -n "$TEXT" ]]; then
+    cleanup_text=$(mktemp -t blog-issue-XXXXXX)
+    printf '%s' "$TEXT" > "$cleanup_text"
+    local effective_kind="$KIND"
+    [[ "$effective_kind" == "auto" || -z "$effective_kind" ]] && effective_kind="post"
+    args+=(--text-file "$cleanup_text" --kind "$effective_kind")
+    [[ -n "$URL" ]] && args+=(--source-url "$URL")
+  else
+    case "$KIND" in
+      paper)            args+=(--pdf "$URL") ;;
+      post)             args+=(--linkedin "$URL") ;;
+      video|auto|"")    args+=("$URL") ;;
+      *) echo "  unknown kind '$KIND'; defaulting to auto"; args+=("$URL") ;;
+    esac
+  fi
+  [[ -n "$TAGS"  ]] && args+=(--tags  "$TAGS")
+  [[ -n "$LANGS" ]] && args+=(--languages "$LANGS")
+  args+=(--issue "$n")
+
+  echo "  running: blog.sh ${args[*]}"
+  if "$SCRIPT_DIR/blog.sh" "${args[@]}"; then
+    echo "  ✓ #$n drafted"
+    [[ -n "$cleanup_text" ]] && rm -f "$cleanup_text"
+    return 0
+  else
+    local rc=$?
+    echo "  ✗ #$n failed ($rc)"
+    [[ -n "$cleanup_text" ]] && rm -f "$cleanup_text"
+    gh issue comment "$n" --repo "$REPO_FULL" --body \
+"Watcher run failed (exit $rc). Likely cause: \`gh pr create\` indexing race (branch may already be on GitHub) or transient network failure. Unassigning so the next tick retries.
+
+If this keeps failing, check the local watcher logs and rerun blog.sh by hand for the same source." >/dev/null
+    gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null
+    return 2
+  fi
+}
+
+# Main loop.
+while true; do
+  if process_one; then
+    : # processed; continue immediately rather than sleep so we drain the queue
+  else
+    [[ "$ONCE" -eq 1 ]] && exit 0
+    sleep "$INTERVAL"
+  fi
+done


### PR DESCRIPTION
## Summary
Two pieces that close the loop from "I want a blog post about this URL" to "PR opened":

- **`.github/ISSUE_TEMPLATE/blog-request.yml`** — a GitHub Issue Form generalised across source kinds. Fields: Source URL (any kind — YouTube, arXiv, LinkedIn, direct PDF, blog post), Source kind (auto/video/paper/post), Tags, Languages, optional Pasted source body (for paywalled inputs), Notes. Auto-applies the new `blog-request` label.
- **`tools/video-to-blog/watch-issues.sh`** — local poller. Picks the oldest unassigned `blog-request` issue (or legacy `video-blog`), claims it, parses the form body, and invokes `blog.sh` with the correct intake flag (`--pdf` / `--linkedin` / positional URL / `--text-file --kind`). Tags / languages / `--issue N` pass through, so the PR's `Closes #N` shuts the issue on merge.

The runner stays local because YouTube blocks GitHub-Actions IPs (this is why the CI flow was retired) and the box is where `gh` / `claude` / `aws` creds live. Run via cron / systemd / tmux.

## Behaviour notes
- One issue at a time per watcher (avoids working-tree races; blog.sh requires a clean tree on master). The watcher drains on success — no sleep between consecutive successes.
- Failures (transient or permanent) get commented to the issue and the runner un-assigns so the next tick retries. The known `gh pr create` indexing race is mentioned by name in the failure comment.
- `--once` drains a single issue and exits — useful for cron or smoke tests.

## Test plan
- [x] YAML form file structurally valid (required-flag dropdowns, defaults).
- [x] `blog-request` label created on the repo (#0E8A16).
- [x] Body parser tested against a synthetic `### Source URL\n\n…\n### Source kind\n\npaper\n…` block — emits the expected JSON.
- [x] `bash -n watch-issues.sh` clean.
- [ ] End-to-end against a fresh test issue (run after merge — needs the form to be live).

## Out of scope
- Auto-creating the legacy `video-blog` issues from this template (those stay closed).
- Multiple parallel watchers — assignment is the lock but two pollers picking the same issue in the same second can race; for now run one watcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)