### PR TITLE
feat(watcher): batch multiple issues into one PR to dodge per-PR rate limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,18 +97,27 @@ content-hashed JS/CSS — no SSR.
    arXiv / LinkedIn / direct PDF / blog post URL — plus optional tags,
    languages, and a `Pasted source body` for paywalled inputs. Then run:
    ```
-   tools/video-to-blog/watch-issues.sh         # default poll interval 60s
+   tools/video-to-blog/watch-issues.sh         # default poll 60s, batch≤10
    WATCH_INTERVAL=30 tools/video-to-blog/watch-issues.sh
-   tools/video-to-blog/watch-issues.sh --once  # drain a single issue and exit
+   BATCH_MAX=20      tools/video-to-blog/watch-issues.sh
+   tools/video-to-blog/watch-issues.sh --once  # one tick, then exit
    ```
-   The poller picks the oldest unassigned issue, claims it (assigns to
-   yourself so a parallel watcher won't double-process), parses the form
-   body into `--pdf`/`--linkedin`/positional URL or `--text-file --kind …`,
-   then invokes `blog.sh` with `--issue N`. The PR's `Closes #N` closes
-   the issue on merge. On failure the watcher comments the error and
-   un-assigns so the next tick retries. Best run on a residential box
-   (cron or systemd-unit) — YouTube blocks GitHub-Actions ranges, and
-   the same machine should hold the gh / claude / aws creds.
+   On each tick the watcher fetches up to `BATCH_MAX` oldest unassigned
+   `blog-request` issues. **One issue → single PR** (current single-issue
+   path: `blog/<slug>` branch, one PR, `Closes #N`). **Two or more →
+   batched into ONE PR** to dodge GitHub's per-PR rate limit and reduce
+   review noise: a shared `blog/batch-<timestamp>` branch holds one commit
+   per drafted post, and the single PR body lists every `Closes #N`. If
+   one draft inside the batch fails, that issue gets a comment + is
+   unassigned for retry, the working tree is reset, and the rest of the
+   batch continues; successful posts still ship in the batch PR. The
+   watcher remembers the branch you started it on (`START_BRANCH`) and
+   returns there at the end of every batch, so running it from a feature
+   branch does not silently revert to master mid-run. blog.sh in
+   `--branch <name> --no-pr` mode is what the watcher invokes per-post.
+   Best run on a residential box (cron or systemd-unit) — YouTube
+   blocks GitHub-Actions ranges, and the same machine should hold the
+   gh / claude / aws creds.
 
 The drafted post gets `source_kind: "video" | "paper" | "post"` in
 `meta.json`, plus `format:<kind>` in the auto-classified `labels` array

--- a/tools/video-to-blog/blog.sh
+++ b/tools/video-to-blog/blog.sh
@@ -18,6 +18,14 @@
 #
 # Common opts: [--tags "a,b,c"] [--languages "en,zh"] [--issue N] [--watch]
 #
+# Batch opts (used by watch-issues.sh — accumulate several drafts on one
+# branch and open a single PR for all of them, to dodge GitHub's
+# per-PR rate limits when draining a queue):
+#   --branch <name>       commit on this branch instead of `blog/<slug>`.
+#                          Created from master if it does not yet exist.
+#   --no-pr               commit but do not push and do not open a PR.
+#                          Caller pushes + opens PR after batching.
+#
 # Stages, all done by this one script:
 #   1. acquire      — fetch+extract source text (or audio→transcript for video)
 #   2. generate     — claude (default) or OpenAI Chat → blog markdown EN+ZH
@@ -32,7 +40,7 @@
 
 set -euo pipefail
 
-usage() { sed -n '2,32p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
+usage() { sed -n '2,39p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
 
 URL=""
 PDF=""
@@ -44,6 +52,8 @@ TAGS=""
 LANGS="en,zh"
 ISSUE=""
 WATCH=0
+BRANCH_OVERRIDE=""
+NO_PR=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pdf)        PDF="$2";        shift 2 ;;
@@ -55,6 +65,8 @@ while [[ $# -gt 0 ]]; do
     --languages)  LANGS="$2";      shift 2 ;;
     --issue)      ISSUE="$2";      shift 2 ;;
     --watch)      WATCH=1;         shift   ;;
+    --branch)     BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --no-pr)      NO_PR=1;         shift   ;;
     -h|--help)    usage 0 ;;
     --)           shift; break ;;
     -*)           echo "Unknown flag: $1" >&2; usage 2 ;;
@@ -128,8 +140,24 @@ if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
   exit 1
 fi
 git -C "$REPO_ROOT" fetch origin >/dev/null 2>&1 || true
-git -C "$REPO_ROOT" checkout master >/dev/null
-git -C "$REPO_ROOT" pull --ff-only origin master >/dev/null 2>&1 || true
+if [[ -n "$BRANCH_OVERRIDE" ]]; then
+  # Batch mode: caller picks the branch. Create from CURRENT HEAD (not
+  # master) if it does not yet exist, otherwise switch to it. Branching
+  # off HEAD matters because, on a single working tree, switching to a
+  # different commit ALSO swaps the on-disk script files. If we branched
+  # from master, the second blog.sh invocation in a batch would read a
+  # stale on-disk blog.sh that doesn't know about --branch / --no-pr and
+  # die with "Unknown flag". The caller (watch-issues.sh) is responsible
+  # for being on a sane base before invoking us.
+  if git -C "$REPO_ROOT" rev-parse --verify "$BRANCH_OVERRIDE" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" checkout "$BRANCH_OVERRIDE" >/dev/null
+  else
+    git -C "$REPO_ROOT" checkout -b "$BRANCH_OVERRIDE" >/dev/null
+  fi
+else
+  git -C "$REPO_ROOT" checkout master >/dev/null
+  git -C "$REPO_ROOT" pull --ff-only origin master >/dev/null 2>&1 || true
+fi
 
 OUT="$(mktemp -d -t v2b-XXXXXX)"
 echo "Pipeline output → $OUT"
@@ -170,9 +198,14 @@ fi
 POST_DIR="public/blog/$SLUG"
 TITLE="$(head -1 "$REPO_ROOT/$POST_DIR/index.en.md" | sed 's/^# //')"
 
-BRANCH="blog/$SLUG"
-# Reuse a stale branch if the same slug was attempted earlier.
-git -C "$REPO_ROOT" checkout -B "$BRANCH" >/dev/null
+if [[ -n "$BRANCH_OVERRIDE" ]]; then
+  # Already on $BRANCH_OVERRIDE from the checkout above; just record it.
+  BRANCH="$BRANCH_OVERRIDE"
+else
+  BRANCH="blog/$SLUG"
+  # Reuse a stale branch if the same slug was attempted earlier.
+  git -C "$REPO_ROOT" checkout -B "$BRANCH" >/dev/null
+fi
 
 git -C "$REPO_ROOT" add "$POST_DIR" public/blog/posts.json
 # Stage the cover image if pipeline.py generated one, and ship it to S3
@@ -193,6 +226,22 @@ fi
 COMMIT_MSG="blog: $TITLE"
 [[ -n "$ISSUE" ]] && COMMIT_MSG+=$'\n\nCloses #'$ISSUE
 git -C "$REPO_ROOT" -c commit.gpgsign=false commit -m "$COMMIT_MSG"
+
+# In batch mode the caller (watch-issues.sh) accumulates several drafts on
+# one branch and opens a single PR at the end. We stop after the commit:
+# no push, no PR, stay on the batch branch so the next iteration can add
+# its own commit on top.
+if [[ "$NO_PR" -eq 1 ]]; then
+  cat <<EOF
+
+✓ Drafted and committed (batch mode — no push, no PR).
+  Slug   : $SLUG
+  Files  : $POST_DIR/
+  Branch : $BRANCH
+EOF
+  exit 0
+fi
+
 git -C "$REPO_ROOT" push -u origin "$BRANCH"
 
 REPO_FULL=$(git -C "$REPO_ROOT" config --get remote.origin.url \

--- a/tools/video-to-blog/watch-issues.sh
+++ b/tools/video-to-blog/watch-issues.sh
@@ -2,17 +2,21 @@
 # watch-issues.sh — poll GitHub issues and draft blog posts from them locally.
 #
 # Loops every $WATCH_INTERVAL seconds (default 60). On each tick:
-#   1. Find one open, unassigned issue labeled `blog-request` (or `video-blog`
-#      for legacy issues).
-#   2. Claim it by assigning to ourselves so a second watcher won't double-process.
-#   3. Parse the issue-form body into URL / kind / tags / languages / pasted text.
-#   4. Run blog.sh with the right arguments. The PR body's `Closes #N` will close
-#      the issue automatically when the PR is merged.
-#   5. On failure, comment with the error and unassign so the issue is retryable.
+#   1. Fetch the oldest UP TO $BATCH_MAX (default 10) open, unassigned issues
+#      labeled `blog-request` (or legacy `video-blog`).
+#   2. If the queue has 1 issue → single-PR path: claim, draft, push, open PR.
+#      If the queue has 2+ issues → BATCH path: claim each, draft each as one
+#      commit on a shared `blog/batch-<timestamp>` branch, then push and open
+#      ONE PR that closes every successful issue. This dodges GitHub's per-PR
+#      rate limit and reduces review noise when draining a backlog.
+#   3. On per-issue failure inside a batch, the watcher comments + unassigns
+#      that issue and resets the working tree so the next iteration is clean;
+#      successful drafts still ship in the batch PR.
 #
 # Usage:
 #   tools/video-to-blog/watch-issues.sh
 #   WATCH_INTERVAL=30 tools/video-to-blog/watch-issues.sh
+#   BATCH_MAX=20      tools/video-to-blog/watch-issues.sh
 #   tools/video-to-blog/watch-issues.sh --once   # single pass for testing
 #
 # Why local instead of CI: drafting from a video URL needs a residential IP
@@ -21,7 +25,7 @@
 
 set -euo pipefail
 
-usage() { sed -n '2,21p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
+usage() { sed -n '2,25p' "${BASH_SOURCE[0]}"; exit "${1:-0}"; }
 
 ONCE=0
 while [[ $# -gt 0 ]]; do
@@ -33,6 +37,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 INTERVAL="${WATCH_INTERVAL:-60}"
+BATCH_MAX="${BATCH_MAX:-10}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Resolve owner/repo. We prefer `gh` over the raw remote URL because repo
@@ -52,7 +57,14 @@ ME=$(gh api user --jq .login 2>/dev/null) || { echo "gh not authenticated. Run: 
 # so we can fail fast if they're missing rather than partway through a draft.
 [[ -f "$REPO_ROOT/.env" ]] && { set -a; . "$REPO_ROOT/.env"; set +a; }
 
-echo "watch-issues: $REPO_FULL  interval=${INTERVAL}s  user=$ME"
+# Remember the branch we started on. The batch path needs to return to it
+# (not blindly to master) at end-of-batch — switching to a different branch
+# also swaps the on-disk copy of blog.sh, and if the watcher was started
+# from a branch with newer logic that hasn't merged to master yet, that
+# revert would break subsequent batches with "Unknown flag: --branch".
+START_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+
+echo "watch-issues: $REPO_FULL  interval=${INTERVAL}s  batch_max=$BATCH_MAX  user=$ME  base=$START_BRANCH"
 [[ "$ONCE" -eq 1 ]] && echo "  (single-pass mode)"
 
 # Parse the issue-form body. Each section is `### Header\n\nbody...` until the
@@ -96,40 +108,37 @@ print(json.dumps({
 '
 }
 
-# One iteration: returns 0 if it processed an issue, 1 if there was nothing
-# to do, 2 if processing failed.
-process_one() {
-  # Pick the oldest unassigned open issue. Sorting by `created` keeps FIFO order
-  # so people whose issues sit longest get drafted first.
+# Pull the oldest unassigned issues. Echoes the JSON array (possibly empty).
+fetch_queue() {
   local raw
   raw=$(gh issue list --repo "$REPO_FULL" \
-        --label blog-request --state open --search 'no:assignee sort:created-asc' \
-        --json number,title,body --limit 1)
+        --label blog-request --state open \
+        --search 'no:assignee sort:created-asc' \
+        --json number,title,body --limit "$BATCH_MAX")
   if [[ "$raw" == "[]" || -z "$raw" ]]; then
     # Fall back to legacy label so a half-migrated issue tracker still works.
     raw=$(gh issue list --repo "$REPO_FULL" \
-          --label video-blog --state open --search 'no:assignee sort:created-asc' \
-          --json number,title,body --limit 1)
+          --label video-blog --state open \
+          --search 'no:assignee sort:created-asc' \
+          --json number,title,body --limit "$BATCH_MAX")
   fi
-  if [[ "$raw" == "[]" || -z "$raw" ]]; then
-    return 1
-  fi
+  printf '%s' "$raw"
+}
 
-  local n title body
-  n=$(jq -r '.[0].number'    <<<"$raw")
-  title=$(jq -r '.[0].title' <<<"$raw")
-  body=$(jq -r '.[0].body'   <<<"$raw")
-  echo "→ #$n  $title"
+# Build the blog.sh argv array for one parsed issue. Sets the global
+# `BLOGSH_ARGS` and `CLEANUP_TEXT` (a tempfile path or empty). Honours the
+# extra `BLOGSH_EXTRA` array (e.g. --branch / --no-pr from the batch path).
+# Returns 0 on success, 2 on parse error / missing source (already commented
+# + unassigned).
+build_blogsh_args_for_issue() {
+  local n="$1" body="$2"
+  BLOGSH_ARGS=()
+  CLEANUP_TEXT=""
 
-  # Claim. If the assign call fails (e.g. someone else just took it) skip and
-  # let the next tick find the next open issue.
-  if ! gh issue edit "$n" --repo "$REPO_FULL" --add-assignee "$ME" >/dev/null 2>&1; then
-    echo "  could not claim #$n; skipping"
-    return 1
-  fi
-
-  # Parse the form body into shell vars.
   local fields URL KIND TAGS LANGS TEXT
+  # Parse failures stay assigned-to-me on purpose: a malformed issue body
+  # needs human inspection before retry. The next tick's `no:assignee`
+  # filter then correctly skips it.
   fields=$(printf '%s' "$body" | parse_issue) || {
     gh issue comment "$n" --repo "$REPO_FULL" \
       --body "Watcher could not parse this issue's body. Please reformat using the issue template, then unassign me." >/dev/null
@@ -144,53 +153,241 @@ process_one() {
   if [[ -z "$URL" && -z "$TEXT" ]]; then
     gh issue comment "$n" --repo "$REPO_FULL" \
       --body "Watcher couldn't find a Source URL or Pasted source body. Add one and unassign me." >/dev/null
-    gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null
+    gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null 2>&1 || true
     return 2
   fi
 
-  # Build blog.sh arguments. Pasted source wins over URL (for paywalled posts).
-  local -a args=()
-  local cleanup_text=""
+  # Pasted source wins over URL (for paywalled posts).
   if [[ -n "$TEXT" ]]; then
-    cleanup_text=$(mktemp -t blog-issue-XXXXXX)
-    printf '%s' "$TEXT" > "$cleanup_text"
+    CLEANUP_TEXT=$(mktemp -t blog-issue-XXXXXX)
+    printf '%s' "$TEXT" > "$CLEANUP_TEXT"
     local effective_kind="$KIND"
     [[ "$effective_kind" == "auto" || -z "$effective_kind" ]] && effective_kind="post"
-    args+=(--text-file "$cleanup_text" --kind "$effective_kind")
-    [[ -n "$URL" ]] && args+=(--source-url "$URL")
+    BLOGSH_ARGS+=(--text-file "$CLEANUP_TEXT" --kind "$effective_kind")
+    [[ -n "$URL" ]] && BLOGSH_ARGS+=(--source-url "$URL")
   else
     case "$KIND" in
-      paper)            args+=(--pdf "$URL") ;;
-      post)             args+=(--linkedin "$URL") ;;
-      video|auto|"")    args+=("$URL") ;;
-      *) echo "  unknown kind '$KIND'; defaulting to auto"; args+=("$URL") ;;
+      paper)            BLOGSH_ARGS+=(--pdf "$URL") ;;
+      post)             BLOGSH_ARGS+=(--linkedin "$URL") ;;
+      video|auto|"")    BLOGSH_ARGS+=("$URL") ;;
+      *) echo "  unknown kind '$KIND'; defaulting to auto"; BLOGSH_ARGS+=("$URL") ;;
     esac
   fi
-  [[ -n "$TAGS"  ]] && args+=(--tags  "$TAGS")
-  [[ -n "$LANGS" ]] && args+=(--languages "$LANGS")
-  args+=(--issue "$n")
+  [[ -n "$TAGS"  ]] && BLOGSH_ARGS+=(--tags  "$TAGS")
+  [[ -n "$LANGS" ]] && BLOGSH_ARGS+=(--languages "$LANGS")
+  BLOGSH_ARGS+=(--issue "$n")
 
-  echo "  running: blog.sh ${args[*]}"
-  if "$SCRIPT_DIR/blog.sh" "${args[@]}"; then
+  # Caller-supplied extras (e.g. --branch <name> --no-pr for batch mode).
+  if [[ "${#BLOGSH_EXTRA[@]}" -gt 0 ]]; then
+    BLOGSH_ARGS+=("${BLOGSH_EXTRA[@]}")
+  fi
+  return 0
+}
+
+# Reset the working tree to the current branch's HEAD. Used between batch
+# iterations so a partial draft from a failed blog.sh doesn't poison the
+# next one. Only touches blog content paths to avoid blowing away anything
+# unexpected in the repo root.
+cleanup_worktree() {
+  git -C "$REPO_ROOT" reset --hard HEAD >/dev/null 2>&1 || true
+  git -C "$REPO_ROOT" clean -fd public/blog public/images/blog >/dev/null 2>&1 || true
+}
+
+# Comment + unassign on a failed issue. Used by both single and batch paths.
+mark_issue_failed() {
+  local n="$1" rc="$2"
+  gh issue comment "$n" --repo "$REPO_FULL" --body \
+"Watcher run failed (exit $rc). Likely cause: \`gh pr create\` indexing race (branch may already be on GitHub), transient network failure, or pipeline error (LLM/transcription). Unassigning so the next tick retries.
+
+If this keeps failing, check the local watcher logs and rerun blog.sh by hand for the same source." >/dev/null 2>&1 || true
+  gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null 2>&1 || true
+}
+
+# Single-issue path: defer to blog.sh end-to-end (it pushes + opens the PR
+# itself). Used when the queue has exactly one item.
+process_single() {
+  local raw="$1"
+  local n title body
+  n=$(jq -r '.[0].number'    <<<"$raw")
+  title=$(jq -r '.[0].title' <<<"$raw")
+  body=$(jq -r '.[0].body'   <<<"$raw")
+  echo "→ #$n  $title  (single)"
+
+  if ! gh issue edit "$n" --repo "$REPO_FULL" --add-assignee "$ME" >/dev/null 2>&1; then
+    echo "  could not claim #$n; skipping"
+    return 1
+  fi
+
+  BLOGSH_EXTRA=()
+  if ! build_blogsh_args_for_issue "$n" "$body"; then
+    return 2
+  fi
+
+  echo "  running: blog.sh ${BLOGSH_ARGS[*]}"
+  if "$SCRIPT_DIR/blog.sh" "${BLOGSH_ARGS[@]}"; then
     echo "  ✓ #$n drafted"
-    [[ -n "$cleanup_text" ]] && rm -f "$cleanup_text"
+    [[ -n "$CLEANUP_TEXT" ]] && rm -f "$CLEANUP_TEXT"
     return 0
   else
     local rc=$?
     echo "  ✗ #$n failed ($rc)"
-    [[ -n "$cleanup_text" ]] && rm -f "$cleanup_text"
-    gh issue comment "$n" --repo "$REPO_FULL" --body \
-"Watcher run failed (exit $rc). Likely cause: \`gh pr create\` indexing race (branch may already be on GitHub) or transient network failure. Unassigning so the next tick retries.
-
-If this keeps failing, check the local watcher logs and rerun blog.sh by hand for the same source." >/dev/null
-    gh issue edit "$n" --repo "$REPO_FULL" --remove-assignee "$ME" >/dev/null
+    [[ -n "$CLEANUP_TEXT" ]] && rm -f "$CLEANUP_TEXT"
+    mark_issue_failed "$n" "$rc"
     return 2
+  fi
+}
+
+# `gh pr create` races GitHub's branch indexing on a fresh push. Mirror the
+# retry budget blog.sh uses so the batch path doesn't fail on the same race.
+pr_create_with_retry() {
+  local branch="$1" title="$2" body="$3"
+  local out=""
+  local max_attempts=10
+  for attempt in $(seq 1 "$max_attempts"); do
+    if out=$(gh pr create \
+        --repo "$REPO_FULL" \
+        --base master \
+        --head "$branch" \
+        --title "$title" \
+        --body "$body" 2>&1); then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [[ $attempt -lt $max_attempts ]]; then
+      local delay=$(( attempt < 5 ? attempt * 5 : 30 ))
+      echo "  gh pr create retry $attempt (sleep ${delay}s) ..." >&2
+      sleep "$delay"
+    fi
+  done
+  echo "$out" >&2
+  return 1
+}
+
+# Batch path: claim N issues, draft each as one commit on a shared branch,
+# push once, open one PR. Each commit message has its own `Closes #N`, and
+# the PR body lists every closure too (so squash-merge or rebase-merge both
+# close every issue).
+process_batch() {
+  local raw="$1" count="$2"
+  local branch_name="blog/batch-$(date +%Y%m%d-%H%M%S)"
+  echo "→ batch of $count issues → $branch_name"
+
+  # Sanity: refuse to start a batch if the working tree is dirty. blog.sh
+  # checks the same thing per call, but this fails earlier.
+  if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+    echo "  working tree dirty in $REPO_ROOT; commit or stash first" >&2
+    return 2
+  fi
+
+  local closed_issues=()        # numbers of issues whose drafts succeeded
+  local successful_titles=()    # post titles, parallel array to closed_issues
+  local successful_slugs=()     # slugs, parallel array to closed_issues
+  local i n title body rc
+  for i in $(seq 0 $((count - 1))); do
+    n=$(jq -r ".[$i].number"    <<<"$raw")
+    title=$(jq -r ".[$i].title" <<<"$raw")
+    body=$(jq -r ".[$i].body"   <<<"$raw")
+    echo "  [$((i + 1))/$count] → #$n  $title"
+
+    if ! gh issue edit "$n" --repo "$REPO_FULL" --add-assignee "$ME" >/dev/null 2>&1; then
+      echo "    could not claim #$n; skipping"
+      continue
+    fi
+
+    BLOGSH_EXTRA=(--branch "$branch_name" --no-pr)
+    if ! build_blogsh_args_for_issue "$n" "$body"; then
+      # build helper already commented + unassigned
+      continue
+    fi
+
+    echo "    running: blog.sh ${BLOGSH_ARGS[*]}"
+    if "$SCRIPT_DIR/blog.sh" "${BLOGSH_ARGS[@]}"; then
+      [[ -n "$CLEANUP_TEXT" ]] && rm -f "$CLEANUP_TEXT"
+      # The most recent commit's title is `blog: <Title>` and its tree
+      # contains the new slug folder. Capture both for the PR body.
+      local last_title last_slug
+      last_title=$(git -C "$REPO_ROOT" log -1 --format=%s | sed -E 's/^blog:[[:space:]]*//')
+      last_slug=$(git -C "$REPO_ROOT" log -1 --name-only --pretty='' \
+                   | grep -E '^public/blog/[^/]+/index\.en\.md$' \
+                   | head -1 | sed -E 's|^public/blog/([^/]+)/index\.en\.md$|\1|' \
+                   || true)
+      closed_issues+=("$n")
+      successful_titles+=("$last_title")
+      successful_slugs+=("${last_slug:-unknown}")
+      echo "    ✓ #$n drafted (slug=${last_slug:-?})"
+    else
+      rc=$?
+      echo "    ✗ #$n failed ($rc)"
+      [[ -n "$CLEANUP_TEXT" ]] && rm -f "$CLEANUP_TEXT"
+      mark_issue_failed "$n" "$rc"
+      # Reset the working tree so a partial draft (untracked slug folder
+      # or a half-staged image) doesn't trip the next blog.sh's clean-tree
+      # check. Successful commits are preserved by `reset --hard HEAD`.
+      cleanup_worktree
+    fi
+  done
+
+  if [[ ${#closed_issues[@]} -eq 0 ]]; then
+    echo "  no drafts succeeded; tearing down empty batch branch"
+    git -C "$REPO_ROOT" checkout "$START_BRANCH" >/dev/null 2>&1 || true
+    git -C "$REPO_ROOT" branch -D "$branch_name" >/dev/null 2>&1 || true
+    return 2
+  fi
+
+  echo "  pushing $branch_name (${#closed_issues[@]} successful drafts)"
+  if ! git -C "$REPO_ROOT" push -u origin "$branch_name" >/dev/null 2>&1; then
+    echo "  push failed — leaving branch + commits in place for manual recovery" >&2
+    git -C "$REPO_ROOT" checkout "$START_BRANCH" >/dev/null 2>&1 || true
+    return 2
+  fi
+
+  # Build PR title + body. Title summarises count; body lists each post +
+  # `Closes #N` so all linked issues close on merge regardless of strategy.
+  local pr_title pr_body
+  pr_title="blog: batch of ${#closed_issues[@]} posts"
+  pr_body="Drafted ${#closed_issues[@]} posts in one batch (single PR to dodge GitHub's per-PR rate limit on backlog drains).
+
+"
+  local k
+  for k in "${!closed_issues[@]}"; do
+    pr_body+="- **${successful_titles[$k]}** (\`${successful_slugs[$k]}\`) — Closes #${closed_issues[$k]}
+"
+  done
+  pr_body+="
+Review each post under \`public/blog/<slug>/\` and merge when satisfied. Both the Pages artifact and the \`dist\` branch redeploy automatically on the merge commit."
+
+  local pr_url
+  if pr_url=$(pr_create_with_retry "$branch_name" "$pr_title" "$pr_body"); then
+    echo "  ✓ batch PR opened: $pr_url"
+  else
+    echo "  ✗ gh pr create exhausted retries; branch is on origin — open the PR by hand:" >&2
+    echo "    gh pr create --base master --head $branch_name --title \"$pr_title\" --body ..." >&2
+    git -C "$REPO_ROOT" checkout "$START_BRANCH" >/dev/null 2>&1 || true
+    return 2
+  fi
+
+  git -C "$REPO_ROOT" checkout "$START_BRANCH" >/dev/null 2>&1 || true
+  return 0
+}
+
+# One tick: fetch the queue, dispatch single or batch.
+process_one_tick() {
+  local raw count
+  raw=$(fetch_queue)
+  if [[ "$raw" == "[]" || -z "$raw" ]]; then
+    return 1
+  fi
+  count=$(jq length <<<"$raw")
+  if [[ "$count" -eq 1 ]]; then
+    process_single "$raw"
+  else
+    process_batch "$raw" "$count"
   fi
 }
 
 # Main loop.
 while true; do
-  if process_one; then
+  if process_one_tick; then
     : # processed; continue immediately rather than sleep so we drain the queue
   else
     [[ "$ONCE" -eq 1 ]] && exit 0

--- a/tools/video-to-blog/watch-issues.sh
+++ b/tools/video-to-blog/watch-issues.sh
@@ -35,8 +35,12 @@ done
 INTERVAL="${WATCH_INTERVAL:-60}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-REPO_FULL=$(git -C "$REPO_ROOT" config --get remote.origin.url \
-  | sed -E 's|.*github\.com[:/]([^/]+/[^.]+).*|\1|')
+# Resolve owner/repo. We prefer `gh` over the raw remote URL because repo
+# names can contain dots (e.g. `jianwang-ntu.github.io`), and a naive
+# `[^.]+` regex on the URL would truncate at the first dot.
+REPO_FULL=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) \
+  || REPO_FULL=$(git -C "$REPO_ROOT" config --get remote.origin.url \
+       | sed -E 's|^.*github\.com[:/](.+)\.git$|\1|; s|^.*github\.com[:/](.+)$|\1|')
 
 # Pre-flight: gh logged in, blog.sh executable, claude on PATH (drafting fails
 # fast if claude is missing, but better to surface early than mid-run).
@@ -56,7 +60,12 @@ echo "watch-issues: $REPO_FULL  interval=${INTERVAL}s  user=$ME"
 # "Source URL" / "Source kind" headers and the legacy "Video URL" header so the
 # watcher works against issues filed before the source-diversity expansion.
 parse_issue() {
-  python3 - <<'PY'
+  # NOTE: the script is passed via `-c`, NOT a heredoc. `python3 - <<'PY'`
+  # redirects stdin to the heredoc, which conflicts with the body we pipe
+  # in — Python ends up reading the body as if it were source code (or
+  # reading nothing) instead of letting the script consume it via
+  # sys.stdin.read(). Using `-c` keeps stdin free for the body.
+  python3 -c '
 import json, re, sys
 body = sys.stdin.read()
 fields = {}
@@ -72,10 +81,19 @@ kind  = (fields.get("source kind") or "auto").strip().lower()
 tags  = fields.get("tags", "").strip()
 langs = (fields.get("languages") or "en,zh").strip()
 text  = fields.get("pasted source body", "")
+# The form renders `Pasted source body` as a code block (`render: text`),
+# so even an empty submission comes back as "```text\n\n```". Strip the
+# fences and treat all-whitespace as empty so we do not invoke
+# `--text-file` with a placeholder.
+m = re.match(r"^```[a-zA-Z0-9_-]*\n(.*?)\n?```\s*$", text, flags=re.S)
+if m:
+    text = m.group(1)
+if not text.strip():
+    text = ""
 print(json.dumps({
     "url": url, "kind": kind, "tags": tags, "langs": langs, "text": text,
 }))
-PY
+'
 }
 
 # One iteration: returns 0 if it processed an issue, 1 if there was nothing


### PR DESCRIPTION
## Why

Filing N blog-request issues used to fan out to N PRs. Draining a backlog (e.g. the six arXiv papers queued in #20–#25) trips GitHub's per-PR rate limit on `gh pr create` and creates a wall of near-identical PRs to review.

## What

`watch-issues.sh` now batches. On each tick the watcher pulls up to `BATCH_MAX` (default 10) oldest unassigned issues:

- **1 issue** → existing single-PR path (`blog/<slug>` branch, one PR, `Closes #N`).
- **2+ issues** → **one** PR. A shared `blog/batch-<timestamp>` branch holds one commit per drafted post. The PR title is `blog: batch of N posts`; the body lists each post with `Closes #M` so every linked issue closes on merge regardless of strategy.

`blog.sh` gains two flags so the watcher can drive it without it opening its own PR per-issue:

| flag | behaviour |
| --- | --- |
| `--branch <name>` | commit on the named branch instead of `blog/<slug>`. Created from **current HEAD** (not master) if missing — see "subtle bit" below. |
| `--no-pr` | commit but don't push and don't open a PR. Caller pushes + opens one PR after batching. |

Default behaviour of `blog.sh` is unchanged.

## Subtle bit (worth a re-read)

On a single working tree, `git checkout` swaps the on-disk files. If `--branch` had branched off `master`, the *first* `blog.sh` invocation in a batch would revert the on-disk `blog.sh` to master's pre-merge version, and the *second* invocation would die with `Unknown flag: --branch`. Two defences:

1. `--branch` creates the new branch off **current HEAD**, not master. Whatever code the caller is running stays on disk.
2. `watch-issues.sh` records `START_BRANCH` at startup and returns to it (not blindly to `master`) at end-of-batch. So you can run the watcher from a feature branch without it silently reverting mid-run.

## Failure handling inside a batch

- Per-issue failure → comment on the issue, unassign, `git reset --hard HEAD` + `git clean -fd public/blog public/images/blog`, continue with the next issue. Successful drafts ahead of the failure are preserved on the batch branch and still ship in the PR.
- Whole batch had zero successes → tear down the empty branch, return.
- `gh pr create` exhausts its 10-attempt retry → the branch is on origin; the watcher prints the manual command and bails.

## Stacking note

This stacks on **#27** (parse-issue heredoc fix + repo-name regex fix). Either:
- merge #27 first, then rebase this onto master, then merge; or
- close #27 and merge this directly (it includes #27's commits transitively).

## Test plan

- [x] `bash -n` clean for both scripts
- [x] `blog.sh --help` renders the new flag docs
- [ ] Merge → run `watch-issues.sh --once` against the live queue (#20–#25) → verify a single batch PR opens with six `Closes #` lines
- [ ] Hit a deliberate failure (e.g. unreachable PDF URL) inside a batch → verify the failed issue's comment + unassign and that the batch continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)