### PR TITLE
style: academic portfolio redesign for Home and Publications

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { Routes, Route, useLocation, Navigate } from 'react-router-dom';
+import { StyleProvider } from './context/StyleCtx.jsx';
 import Home from './pages/Home.jsx';
 import Publications from './pages/Publications.jsx';
 import WorkProjects from './pages/WorkProjects.jsx';
@@ -15,7 +16,7 @@ function ScrollToTop() {
 
 export default function App() {
   return (
-    <>
+    <StyleProvider>
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Navigate to="/home" replace />} />
@@ -27,6 +28,6 @@ export default function App() {
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="*" element={<Navigate to="/home" replace />} />
       </Routes>
-    </>
+    </StyleProvider>
   );
 }

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import { useStyleMode } from '../context/StyleCtx.jsx';
 
 const NAV_ITEMS = [
   { to: '/home', label: 'Home' },
@@ -10,6 +11,7 @@ const NAV_ITEMS = [
 ];
 
 export default function Nav() {
+  const { mode, toggle } = useStyleMode();
   return (
     <nav className="nav">
       <NavLink to="/home" className="brand" style={{ textDecoration: 'none', color: 'var(--ink)' }}>
@@ -25,6 +27,13 @@ export default function Nav() {
             {n.label}
           </NavLink>
         ))}
+        <button
+          className="style-toggle"
+          onClick={toggle}
+          title={mode === 'academic' ? 'Switch to classic style' : 'Switch to academic style'}
+        >
+          {mode === 'academic' ? '◧ classic' : '◨ academic'}
+        </button>
       </div>
     </nav>
   );

--- a/src/context/StyleCtx.jsx
+++ b/src/context/StyleCtx.jsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'wj-style-mode';
+const DEFAULT_MODE = 'academic'; // new default
+
+const StyleCtx = createContext({ mode: DEFAULT_MODE, toggle: () => {} });
+
+export function StyleProvider({ children }) {
+  const [mode, setMode] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored === 'classic' || stored === 'academic' ? stored : DEFAULT_MODE;
+    } catch {
+      return DEFAULT_MODE;
+    }
+  });
+
+  const toggle = useCallback(() => {
+    setMode((prev) => {
+      const next = prev === 'academic' ? 'classic' : 'academic';
+      try { localStorage.setItem(STORAGE_KEY, next); } catch {}
+      return next;
+    });
+  }, []);
+
+  return <StyleCtx.Provider value={{ mode, toggle }}>{children}</StyleCtx.Provider>;
+}
+
+export function useStyleMode() {
+  return useContext(StyleCtx);
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,9 +2,131 @@ import React from 'react';
 import Nav from '../components/Nav.jsx';
 import Footer from '../components/Footer.jsx';
 import Seo from '../components/Seo.jsx';
+import { Chip, Note, Tag, Thumb, SectionHead } from '../components/primitives.jsx';
+import { useStyleMode } from '../context/StyleCtx.jsx';
 import { NEWS, FEATURED_PUBS } from '../data.jsx';
 
-function PubEntry({ p }) {
+/* ─── shared badge renderer ───────────────────────────────────────── */
+function PubBadge({ b }) {
+  if (b.href) {
+    return (
+      <a href={b.href} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
+        <Tag>{b.label}</Tag>
+      </a>
+    );
+  }
+  return <Tag>{b.label}</Tag>;
+}
+
+/* ─── Classic layout pieces ─────────────────────────────────────── */
+function ClassicPubRow({ p }) {
+  return (
+    <div className="pub-row">
+      <Thumb label={p.thumb} w={90} h={64} />
+      <div style={{ flex: 1 }}>
+        <div className="pub-title">{p.title}</div>
+        <div className="pub-authors">{p.authors}</div>
+        <div className="pub-meta">
+          <span className="venue">{p.venue} · {p.year}</span>
+          {p.badges?.map((b, i) => <PubBadge key={i} b={b} />)}
+          {p.note && <Note>{p.note}</Note>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ClassicNewsItem({ date, children }) {
+  return (
+    <div className="news-item">
+      <span className="date">{date}</span>
+      <span style={{ flex: 1 }}>{children}</span>
+    </div>
+  );
+}
+
+function ClassicHome() {
+  return (
+    <>
+      <section className="home-hero">
+        <div>
+          <div className="kicker" style={{ letterSpacing: 2 }}>
+            NTU PhD · SMU RESEARCH · CODE LLM SECURITY
+          </div>
+          <h1>Code LLM security<br /><u>and intelligence.</u></h1>
+          <div className="lede">
+            I'm <b>Jian Wang (王剑)</b>, a recent PhD from the College of Computing
+            and Data Science (CCDS), <b>Nanyang Technological University</b>,
+            advised by{' '}
+            <a href="https://personal.ntu.edu.sg/yi_li/" target="_blank" rel="noreferrer">Prof. Li Yi</a>.
+            My research sits at the intersection of <b>software engineering</b>,{' '}
+            <b>large language models</b>, and <b>trustworthy AI systems</b> — from
+            automated program repair and AIGC code detection to execution-grounded
+            reasoning over programs. Before research I spent <b>~8 years</b> in
+            industry: AI Lab at Xiaomi (trained GANs for portrait background removal
+            and face cartoonisation) and a backend role at 58.com (high-performance
+            async web framework serving 100M+ daily requests).
+          </div>
+          <div className="ctas">
+            <Chip solid href="/data/JianWang_cv.pdf">↓ Download CV</Chip>
+            <Chip href="mailto:jian004@e.ntu.edu.sg">Email →</Chip>
+            <Chip href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ">Scholar</Chip>
+            <Chip href="https://twitter.com/jornbowrl">Twitter</Chip>
+          </div>
+        </div>
+        <div className="headshot" style={{ background: 'var(--bg)', padding: 0 }}>
+          <img
+            src="/images/headshot-ai.png"
+            alt="Jian Wang"
+            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+              e.currentTarget.parentElement.innerHTML =
+                '<span style="background:rgba(250,250,247,0.6);padding:4px;font-family:var(--mono);font-size:10px">[photo]</span>';
+            }}
+          />
+        </div>
+      </section>
+
+      <section className="home-body">
+        <div>
+          <SectionHead>Featured work</SectionHead>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {FEATURED_PUBS.map((p, i) => <ClassicPubRow key={i} p={p} />)}
+          </div>
+          <div style={{ marginTop: 14, fontFamily: 'var(--mono)', fontSize: 11 }}>
+            → <a href="/pubs">see all publications</a> · <a href="/work">see the work behind them</a>
+          </div>
+        </div>
+        <div>
+          <SectionHead>News</SectionHead>
+          <div className="news-list">
+            {NEWS.slice(0, 7).map(([d, t], i) => <ClassicNewsItem key={i} date={d}>{t}</ClassicNewsItem>)}
+          </div>
+          <div style={{ marginTop: 24 }}>
+            <SectionHead>Awards</SectionHead>
+            <div style={{ fontSize: 11.5, lineHeight: 1.7 }}>
+              <div>★ <b>S$100,000 prize</b> · 3rd place · AI Singapore Deepfake Detection Challenge · 2022</div>
+              <div>★ AI / Computer Vision certification · Tsinghua University · 2019</div>
+            </div>
+          </div>
+          <div style={{ marginTop: 24 }}>
+            <SectionHead>Research interests</SectionHead>
+            <div style={{ fontSize: 11.5, lineHeight: 1.7 }}>
+              <div>· Automated program repair (LLM-based)</div>
+              <div>· AI-generated code detection</div>
+              <div>· Execution-trace reasoning for code LLMs</div>
+              <div>· Robustness & fairness of neural systems</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+/* ─── Academic layout pieces ────────────────────────────────────── */
+function AcademicPubEntry({ p }) {
   const firstLink = p.badges?.[0];
   return (
     <div className="home-pub-entry">
@@ -29,28 +151,17 @@ function PubEntry({ p }) {
   );
 }
 
-export default function Home() {
+function AcademicHome() {
   return (
-    <div className="page">
-      <Seo
-        title="Home"
-        description="Jian Wang — PhD, NTU Singapore. Research on code LLM security, automated program repair, and AI-generated code detection."
-        path="/home"
-      />
-      <Nav />
-
-      {/* ── Profile / About ─────────────────────────────────────────── */}
+    <>
       <section className="about-section">
-
         {/* Left: profile card */}
         <div className="profile-card">
           <img
             src="/images/jornbowrl_circle.jpg"
             alt="Jian Wang"
             className="profile-avatar"
-            onError={(e) => {
-              e.currentTarget.src = '/images/headshot-ai.png';
-            }}
+            onError={(e) => { e.currentTarget.src = '/images/headshot-ai.png'; }}
           />
           <h2 className="profile-name">Jian Wang</h2>
           <p className="profile-sub">王剑</p>
@@ -107,7 +218,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* ── Selected Publications ──────────────────────────────────── */}
       <section className="home-pubs-section">
         <h2 className="bio-section-h">Selected Publications</h2>
         <p className="home-pubs-intro">
@@ -115,9 +225,24 @@ export default function Home() {
           <a href="/pubs">see all publications</a> ·{' '}
           <a href="/work">see the work behind them</a>
         </p>
-        {FEATURED_PUBS.map((p, i) => <PubEntry key={i} p={p} />)}
+        {FEATURED_PUBS.map((p, i) => <AcademicPubEntry key={i} p={p} />)}
       </section>
+    </>
+  );
+}
 
+/* ─── Page shell ──────────────────────────────────────────────────── */
+export default function Home() {
+  const { mode } = useStyleMode();
+  return (
+    <div className="page">
+      <Seo
+        title="Home"
+        description="Jian Wang — PhD, NTU Singapore. Research on code LLM security, automated program repair, and AI-generated code detection."
+        path="/home"
+      />
+      <Nav />
+      {mode === 'academic' ? <AcademicHome /> : <ClassicHome />}
       <Footer />
     </div>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,42 +2,29 @@ import React from 'react';
 import Nav from '../components/Nav.jsx';
 import Footer from '../components/Footer.jsx';
 import Seo from '../components/Seo.jsx';
-import { Chip, Note, Tag, Thumb, SectionHead } from '../components/primitives.jsx';
 import { NEWS, FEATURED_PUBS } from '../data.jsx';
 
-function PubBadge({ b }) {
-  if (b.href) {
-    return (
-      <a href={b.href} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
-        <Tag>{b.label}</Tag>
-      </a>
-    );
-  }
-  return <Tag>{b.label}</Tag>;
-}
-
-function PubRow({ p }) {
+function PubEntry({ p }) {
+  const firstLink = p.badges?.[0];
   return (
-    <div className="pub-row">
-      <Thumb label={p.thumb} w={90} h={64} />
-      <div style={{ flex: 1 }}>
-        <div className="pub-title">{p.title}</div>
-        <div className="pub-authors">{p.authors}</div>
-        <div className="pub-meta">
-          <span className="venue">{p.venue} · {p.year}</span>
-          {p.badges?.map((b, i) => <PubBadge key={i} b={b} />)}
-          {p.note && <Note>{p.note}</Note>}
-        </div>
+    <div className="home-pub-entry">
+      <div className="home-pub-title">
+        {firstLink?.href
+          ? <a href={firstLink.href} target="_blank" rel="noreferrer">{p.title}</a>
+          : p.title}
+        {p.note && <span className="home-pub-featured">{p.note}</span>}
       </div>
-    </div>
-  );
-}
-
-function NewsItem({ date, children }) {
-  return (
-    <div className="news-item">
-      <span className="date">{date}</span>
-      <span style={{ flex: 1 }}>{children}</span>
+      <div className="home-pub-authors">{p.authors}</div>
+      <div className="home-pub-venue">{p.venue} · {p.year}</div>
+      {p.badges && p.badges.length > 0 && (
+        <div className="home-pub-links">
+          {p.badges.map((b, i) =>
+            b.href
+              ? <a key={i} href={b.href} target="_blank" rel="noreferrer" className="pub-lnk">{b.label}</a>
+              : <span key={i} className="pub-lnk">{b.label}</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -51,78 +38,84 @@ export default function Home() {
         path="/home"
       />
       <Nav />
-      <section className="home-hero">
-        <div>
-          <div className="kicker" style={{ letterSpacing: 2 }}>
-            NTU PhD · SMU RESEARCH · CODE LLM SECURITY
+
+      {/* ── Profile / About ─────────────────────────────────────────── */}
+      <section className="about-section">
+
+        {/* Left: profile card */}
+        <div className="profile-card">
+          <img
+            src="/images/jornbowrl_circle.jpg"
+            alt="Jian Wang"
+            className="profile-avatar"
+            onError={(e) => {
+              e.currentTarget.src = '/images/headshot-ai.png';
+            }}
+          />
+          <h2 className="profile-name">Jian Wang</h2>
+          <p className="profile-sub">王剑</p>
+          <p className="profile-sub">PhD · NTU Singapore</p>
+          <p className="profile-sub">Code LLM Security</p>
+          <div className="profile-links">
+            <a href="mailto:jian004@e.ntu.edu.sg" className="soc-link">Email</a>
+            <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer" className="soc-link">Scholar</a>
+            <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer" className="soc-link">GitHub</a>
+            <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer" className="soc-link">Twitter</a>
           </div>
-          <h1>Code LLM security<br /><u>and intelligence.</u></h1>
-          <div className="lede">
-            I'm <b>Jian Wang (王剑)</b>, a recent PhD from the College of Computing
-            and Data Science (CCDS), <b>Nanyang Technological University</b>,
-            advised by{' '}
+          <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer" className="cv-download">↓ Download CV</a>
+        </div>
+
+        {/* Right: bio + interests + news */}
+        <div className="bio-column">
+          <h2 className="bio-section-h">Biography</h2>
+          <p className="bio-text">
+            I'm a recent PhD from the College of Computing and Data Science (CCDS) at{' '}
+            <b>Nanyang Technological University</b>, advised by{' '}
             <a href="https://personal.ntu.edu.sg/yi_li/" target="_blank" rel="noreferrer">Prof. Li Yi</a>.
             My research sits at the intersection of <b>software engineering</b>,{' '}
             <b>large language models</b>, and <b>trustworthy AI systems</b> — from
             automated program repair and AIGC code detection to execution-grounded
-            reasoning over programs. Before research I spent <b>~8 years</b> in
-            industry: AI Lab at Xiaomi (trained GANs for portrait background removal
-            and face cartoonisation) and a backend role at 58.com (high-performance
-            async web framework serving 100M+ daily requests).
+            reasoning over programs.
+          </p>
+          <p className="bio-text">
+            Before research I spent <b>~8 years</b> in industry: AI Lab at Xiaomi (trained
+            GANs for portrait background removal and face cartoonisation) and a backend role
+            at 58.com (high-performance async web framework serving 100M+ daily requests).
+          </p>
+
+          <h2 className="bio-section-h" style={{ marginTop: 22 }}>Research Interests</h2>
+          <ul className="bio-interests">
+            <li>Automated program repair (LLM-based)</li>
+            <li>AI-generated code detection</li>
+            <li>Execution-trace reasoning for code LLMs</li>
+            <li>Robustness &amp; fairness of neural systems</li>
+          </ul>
+
+          <h2 className="bio-section-h">News</h2>
+          <div className="bio-news">
+            {NEWS.slice(0, 7).map(([d, t], i) => (
+              <div key={i} className="news-row">
+                <span className="news-date">{d}</span>
+                <span>{t}</span>
+              </div>
+            ))}
           </div>
-          <div className="ctas">
-            <Chip solid href="/data/JianWang_cv.pdf">↓ Download CV</Chip>
-            <Chip href="mailto:jian004@e.ntu.edu.sg">Email →</Chip>
-            <Chip href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ">Scholar</Chip>
-            <Chip href="https://twitter.com/jornbowrl">Twitter</Chip>
-          </div>
-        </div>
-        <div className="headshot" style={{ background: 'var(--bg)', padding: 0 }}>
-          <img
-            src="/images/headshot-ai.png"
-            alt="Jian Wang"
-            style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-              e.currentTarget.parentElement.innerHTML =
-                '<span style="background: rgba(250,250,247,0.6); padding: 4px; font-family: var(--mono); font-size: 10px;">[photo]</span>';
-            }}
-          />
+
+          <p style={{ marginTop: 18, fontFamily: 'var(--mono)', fontSize: 11, lineHeight: 1.6 }}>
+            ★ <b>S$100,000 prize</b> · 3rd place · AI Singapore Deepfake Detection Challenge · 2022
+          </p>
         </div>
       </section>
 
-      <section className="home-body">
-        <div>
-          <SectionHead>Featured work</SectionHead>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            {FEATURED_PUBS.map((p, i) => <PubRow key={i} p={p} />)}
-          </div>
-          <div style={{ marginTop: 14, fontFamily: 'var(--mono)', fontSize: 11 }}>
-            → <a href="/pubs">see all publications</a> · <a href="/work">see the work behind them</a>
-          </div>
-        </div>
-        <div>
-          <SectionHead>News</SectionHead>
-          <div className="news-list">
-            {NEWS.slice(0, 7).map(([d, t], i) => <NewsItem key={i} date={d}>{t}</NewsItem>)}
-          </div>
-          <div style={{ marginTop: 24 }}>
-            <SectionHead>Awards</SectionHead>
-            <div style={{ fontSize: 11.5, lineHeight: 1.7 }}>
-              <div>★ <b>S$100,000 prize</b> · 3rd place · AI Singapore Deepfake Detection Challenge · 2022</div>
-              <div>★ AI / Computer Vision certification · Tsinghua University · 2019</div>
-            </div>
-          </div>
-          <div style={{ marginTop: 24 }}>
-            <SectionHead>Research interests</SectionHead>
-            <div style={{ fontSize: 11.5, lineHeight: 1.7 }}>
-              <div>· Automated program repair (LLM-based)</div>
-              <div>· AI-generated code detection</div>
-              <div>· Execution-trace reasoning for code LLMs</div>
-              <div>· Robustness & fairness of neural systems</div>
-            </div>
-          </div>
-        </div>
+      {/* ── Selected Publications ──────────────────────────────────── */}
+      <section className="home-pubs-section">
+        <h2 className="bio-section-h">Selected Publications</h2>
+        <p className="home-pubs-intro">
+          <b>Bold</b> author is me. →{' '}
+          <a href="/pubs">see all publications</a> ·{' '}
+          <a href="/work">see the work behind them</a>
+        </p>
+        {FEATURED_PUBS.map((p, i) => <PubEntry key={i} p={p} />)}
       </section>
 
       <Footer />

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -1,47 +1,31 @@
 import React from 'react';
 import Nav from '../components/Nav.jsx';
 import Footer from '../components/Footer.jsx';
-import PageHead from '../components/PageHead.jsx';
 import Seo from '../components/Seo.jsx';
-import { Box, Chip, Note, Tag, Thumb } from '../components/primitives.jsx';
 import { ALL_PUBS } from '../data.jsx';
 
-function PubBadge({ b }) {
-  if (b.href) {
-    return (
-      <a href={b.href} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
-        <Tag>{b.label}</Tag>
-      </a>
-    );
-  }
-  return <Tag>{b.label}</Tag>;
-}
-
-function YearHead({ y, count }) {
+function PubEntry({ p }) {
+  const firstLink = p.badges?.[0];
   return (
-    <div className="year-head">
-      <span className="yr">{y}</span>
-      <span className="kicker">{count} ITEM{count !== 1 ? 'S' : ''}</span>
-      <div className="rule" />
-    </div>
-  );
-}
-
-function PubItem({ id, thumb, title, authors, venue, year, badges, note }) {
-  return (
-    <div className="pub-item">
-      <div className="pub-id">[{id}]</div>
-      <Thumb label={thumb} w={110} h={78} />
-      <div>
-        <div className="pub-title-l">{title}</div>
-        <div style={{ fontStyle: 'italic', marginTop: 3, opacity: 0.85, fontSize: 12.5 }}>{authors}</div>
-        <div style={{ display: 'flex', gap: 8, marginTop: 7, alignItems: 'center', flexWrap: 'wrap' }}>
-          <span style={{ fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700 }}>{venue} · {year}</span>
-          {badges?.map((b, i) => <PubBadge key={i} b={b} />)}
-          {note && <Note>{note}</Note>}
-        </div>
+    <article className="pub-entry">
+      <div className="pub-entry-title">
+        {firstLink?.href
+          ? <a href={firstLink.href} target="_blank" rel="noreferrer">{p.title}</a>
+          : p.title}
+        {p.note && <span className="pub-entry-feat">{p.note}</span>}
       </div>
-    </div>
+      <div className="pub-entry-authors">{p.authors}</div>
+      <div className="pub-entry-venue">{p.venue} · {p.year}</div>
+      {p.badges && p.badges.length > 0 && (
+        <div className="pub-entry-links">
+          {p.badges.map((b, i) =>
+            b.href
+              ? <a key={i} href={b.href} target="_blank" rel="noreferrer" className="pub-entry-lnk">{b.label}</a>
+              : <span key={i} className="pub-entry-lnk">{b.label}</span>
+          )}
+        </div>
+      )}
+    </article>
   );
 }
 
@@ -49,7 +33,6 @@ export default function Publications() {
   const byYear = {};
   ALL_PUBS.forEach((p) => { (byYear[p.year] = byYear[p.year] || []).push(p); });
   const years = Object.keys(byYear).map(Number).sort((a, b) => b - a);
-  const kindCount = ALL_PUBS.reduce((acc, p) => { acc[p.kind] = (acc[p.kind] || 0) + 1; return acc; }, {});
 
   return (
     <div className="page">
@@ -59,57 +42,58 @@ export default function Publications() {
         path="/pubs"
       />
       <Nav />
-      <PageHead
-        kicker={`PUBLICATIONS · ${years[years.length - 1]} — ${years[0]}`}
-        title={<span>Papers on code LLMs,<br />repair, & <u>trustworthy AI.</u></span>}
-        blurb={<><b>Bold</b> author is me. {ALL_PUBS.length} papers across SE, ML, and security venues. For the work that grounds each paper, see <a href="/work">Work & Projects</a>.</>}
-        right={
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, fontFamily: 'var(--mono)', fontSize: 10 }}>
-            <div className="kicker">VIEW</div>
-            <div style={{ display: 'flex', gap: 6 }}>
-              <Chip sm solid>by year</Chip>
-              <Chip sm href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ">scholar</Chip>
-            </div>
+
+      <div className="pubs-page">
+
+        {/* ── Left sidebar ──────────────────────────────────────────── */}
+        <div className="pubs-sidebar">
+          <img
+            src="/images/jornbowrl_circle.jpg"
+            alt="Jian Wang"
+            className="sidebar-avatar"
+            onError={(e) => {
+              e.currentTarget.src = '/images/headshot-ai.png';
+              e.currentTarget.onerror = null;
+            }}
+          />
+          <h3 className="sidebar-name">Jian Wang</h3>
+          <p className="sidebar-bio">
+            PhD · NTU Singapore<br />
+            Code LLM Security &amp; Program Repair
+          </p>
+          <div className="sidebar-links">
+            <a href="mailto:jian004@e.ntu.edu.sg">Email</a>
+            <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>
+            <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer">GitHub</a>
+            <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer">Twitter</a>
+            <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">CV (PDF)</a>
           </div>
-        }
-      />
-      <div className="pub-filter">
-        <span style={{ opacity: 0.55 }}>filter →</span>
-        <Tag>all ({ALL_PUBS.length})</Tag>
-        <Tag>conference ({kindCount.conference || 0})</Tag>
-        <Tag>journal ({kindCount.journal || 0})</Tag>
-        <span style={{ opacity: 0.4, margin: '0 4px' }}>·</span>
-        <Tag>code LLMs</Tag><Tag>program repair</Tag><Tag>AIGC detection</Tag><Tag>DL testing</Tag>
-        <span style={{ marginLeft: 'auto', opacity: 0.55 }}>
-          <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">↗ Google Scholar</a>
-        </span>
+        </div>
+
+        {/* ── Main publications list ─────────────────────────────── */}
+        <div className="pubs-main">
+          <h1 className="pubs-page-title">Publications</h1>
+          <p className="pubs-intro">
+            <b>Bold</b> author is me. {ALL_PUBS.length} papers across SE, ML, and security venues.{' '}
+            See also <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.
+          </p>
+
+          {years.map((y) => (
+            <React.Fragment key={y}>
+              <h2 className="pubs-year-h">{y}</h2>
+              {byYear[y].map((p) => <PubEntry key={p.id} p={p} />)}
+            </React.Fragment>
+          ))}
+
+          <p style={{ marginTop: 36, fontFamily: 'var(--mono)', fontSize: 11, opacity: 0.55, lineHeight: 1.6 }}>
+            For older / co-authored work, see{' '}
+            <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">
+              Google Scholar
+            </a>.{' '}·{' '}
+            <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a>
+          </p>
+        </div>
       </div>
-
-      <section className="content">
-        {years.map((y) => (
-          <React.Fragment key={y}>
-            <YearHead y={y} count={byYear[y].length} />
-            {byYear[y].map((p) => (
-              <PubItem
-                key={p.id}
-                id={p.id}
-                thumb={p.venue.split(' ')[0].toLowerCase()}
-                title={p.title}
-                authors={p.authors}
-                venue={p.venue}
-                year={p.year}
-                badges={p.badges}
-                note={p.note}
-              />
-            ))}
-          </React.Fragment>
-        ))}
-
-        <Box dashed style={{ marginTop: 36, padding: 16, display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--mono)', fontSize: 11, gap: 16, flexWrap: 'wrap' }}>
-          <span>For older / co-authored work, see <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.</span>
-          <span><a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a></span>
-        </Box>
-      </section>
 
       <Footer />
     </div>

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -1,10 +1,111 @@
 import React from 'react';
 import Nav from '../components/Nav.jsx';
 import Footer from '../components/Footer.jsx';
+import PageHead from '../components/PageHead.jsx';
 import Seo from '../components/Seo.jsx';
+import { Box, Chip, Note, Tag, Thumb } from '../components/primitives.jsx';
+import { useStyleMode } from '../context/StyleCtx.jsx';
 import { ALL_PUBS } from '../data.jsx';
 
-function PubEntry({ p }) {
+/* ─── shared badge ──────────────────────────────────────────────── */
+function PubBadge({ b }) {
+  if (b.href) {
+    return (
+      <a href={b.href} target="_blank" rel="noreferrer" style={{ textDecoration: 'none' }}>
+        <Tag>{b.label}</Tag>
+      </a>
+    );
+  }
+  return <Tag>{b.label}</Tag>;
+}
+
+/* ─── Classic layout ─────────────────────────────────────────────── */
+function YearHead({ y, count }) {
+  return (
+    <div className="year-head">
+      <span className="yr">{y}</span>
+      <span className="kicker">{count} ITEM{count !== 1 ? 'S' : ''}</span>
+      <div className="rule" />
+    </div>
+  );
+}
+
+function ClassicPubItem({ id, thumb, title, authors, venue, year, badges, note }) {
+  return (
+    <div className="pub-item">
+      <div className="pub-id">[{id}]</div>
+      <Thumb label={thumb} w={110} h={78} />
+      <div>
+        <div className="pub-title-l">{title}</div>
+        <div style={{ fontStyle: 'italic', marginTop: 3, opacity: 0.85, fontSize: 12.5 }}>{authors}</div>
+        <div style={{ display: 'flex', gap: 8, marginTop: 7, alignItems: 'center', flexWrap: 'wrap' }}>
+          <span style={{ fontFamily: 'var(--mono)', fontSize: 10, fontWeight: 700 }}>{venue} · {year}</span>
+          {badges?.map((b, i) => <PubBadge key={i} b={b} />)}
+          {note && <Note>{note}</Note>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ClassicPublications({ byYear, years, kindCount }) {
+  return (
+    <>
+      <PageHead
+        kicker={`PUBLICATIONS · ${years[years.length - 1]} — ${years[0]}`}
+        title={<span>Papers on code LLMs,<br />repair, & <u>trustworthy AI.</u></span>}
+        blurb={<><b>Bold</b> author is me. {ALL_PUBS.length} papers across SE, ML, and security venues. For the work that grounds each paper, see <a href="/work">Work & Projects</a>.</>}
+        right={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, fontFamily: 'var(--mono)', fontSize: 10 }}>
+            <div className="kicker">VIEW</div>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <Chip sm solid>by year</Chip>
+              <Chip sm href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ">scholar</Chip>
+            </div>
+          </div>
+        }
+      />
+      <div className="pub-filter">
+        <span style={{ opacity: 0.55 }}>filter →</span>
+        <Tag>all ({ALL_PUBS.length})</Tag>
+        <Tag>conference ({kindCount.conference || 0})</Tag>
+        <Tag>journal ({kindCount.journal || 0})</Tag>
+        <span style={{ opacity: 0.4, margin: '0 4px' }}>·</span>
+        <Tag>code LLMs</Tag><Tag>program repair</Tag><Tag>AIGC detection</Tag><Tag>DL testing</Tag>
+        <span style={{ marginLeft: 'auto', opacity: 0.55 }}>
+          <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">↗ Google Scholar</a>
+        </span>
+      </div>
+      <section className="content">
+        {years.map((y) => (
+          <React.Fragment key={y}>
+            <YearHead y={y} count={byYear[y].length} />
+            {byYear[y].map((p) => (
+              <ClassicPubItem
+                key={p.id}
+                id={p.id}
+                thumb={p.venue.split(' ')[0].toLowerCase()}
+                title={p.title}
+                authors={p.authors}
+                venue={p.venue}
+                year={p.year}
+                badges={p.badges}
+                note={p.note}
+              />
+            ))}
+          </React.Fragment>
+        ))}
+        <Box dashed style={{ marginTop: 36, padding: 16, display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--mono)', fontSize: 11, gap: 16, flexWrap: 'wrap' }}>
+          <span>For older / co-authored work, see <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.</span>
+          <span><a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a></span>
+        </Box>
+      </section>
+    </>
+  );
+}
+
+/* ─── Academic layout ────────────────────────────────────────────── */
+function AcademicPubEntry({ p }) {
   const firstLink = p.badges?.[0];
   return (
     <article className="pub-entry">
@@ -29,10 +130,64 @@ function PubEntry({ p }) {
   );
 }
 
+function AcademicPublications({ byYear, years }) {
+  return (
+    <div className="pubs-page">
+      {/* Left sidebar */}
+      <div className="pubs-sidebar">
+        <img
+          src="/images/jornbowrl_circle.jpg"
+          alt="Jian Wang"
+          className="sidebar-avatar"
+          onError={(e) => { e.currentTarget.src = '/images/headshot-ai.png'; e.currentTarget.onerror = null; }}
+        />
+        <h3 className="sidebar-name">Jian Wang</h3>
+        <p className="sidebar-bio">
+          PhD · NTU Singapore<br />
+          Code LLM Security &amp; Program Repair
+        </p>
+        <div className="sidebar-links">
+          <a href="mailto:jian004@e.ntu.edu.sg">Email</a>
+          <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>
+          <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer">Twitter</a>
+          <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">CV (PDF)</a>
+        </div>
+      </div>
+
+      {/* Main publications list */}
+      <div className="pubs-main">
+        <h1 className="pubs-page-title">Publications</h1>
+        <p className="pubs-intro">
+          <b>Bold</b> author is me. {ALL_PUBS.length} papers across SE, ML, and security venues.{' '}
+          See also <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.
+        </p>
+
+        {years.map((y) => (
+          <React.Fragment key={y}>
+            <h2 className="pubs-year-h">{y}</h2>
+            {byYear[y].map((p) => <AcademicPubEntry key={p.id} p={p} />)}
+          </React.Fragment>
+        ))}
+
+        <p style={{ marginTop: 36, fontFamily: 'var(--mono)', fontSize: 11, opacity: 0.55, lineHeight: 1.6 }}>
+          For older / co-authored work, see{' '}
+          <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.{' '}·{' '}
+          <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Page shell ──────────────────────────────────────────────────── */
 export default function Publications() {
+  const { mode } = useStyleMode();
+
   const byYear = {};
   ALL_PUBS.forEach((p) => { (byYear[p.year] = byYear[p.year] || []).push(p); });
   const years = Object.keys(byYear).map(Number).sort((a, b) => b - a);
+  const kindCount = ALL_PUBS.reduce((acc, p) => { acc[p.kind] = (acc[p.kind] || 0) + 1; return acc; }, {});
 
   return (
     <div className="page">
@@ -42,59 +197,10 @@ export default function Publications() {
         path="/pubs"
       />
       <Nav />
-
-      <div className="pubs-page">
-
-        {/* ── Left sidebar ──────────────────────────────────────────── */}
-        <div className="pubs-sidebar">
-          <img
-            src="/images/jornbowrl_circle.jpg"
-            alt="Jian Wang"
-            className="sidebar-avatar"
-            onError={(e) => {
-              e.currentTarget.src = '/images/headshot-ai.png';
-              e.currentTarget.onerror = null;
-            }}
-          />
-          <h3 className="sidebar-name">Jian Wang</h3>
-          <p className="sidebar-bio">
-            PhD · NTU Singapore<br />
-            Code LLM Security &amp; Program Repair
-          </p>
-          <div className="sidebar-links">
-            <a href="mailto:jian004@e.ntu.edu.sg">Email</a>
-            <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>
-            <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer">GitHub</a>
-            <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer">Twitter</a>
-            <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">CV (PDF)</a>
-          </div>
-        </div>
-
-        {/* ── Main publications list ─────────────────────────────── */}
-        <div className="pubs-main">
-          <h1 className="pubs-page-title">Publications</h1>
-          <p className="pubs-intro">
-            <b>Bold</b> author is me. {ALL_PUBS.length} papers across SE, ML, and security venues.{' '}
-            See also <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.
-          </p>
-
-          {years.map((y) => (
-            <React.Fragment key={y}>
-              <h2 className="pubs-year-h">{y}</h2>
-              {byYear[y].map((p) => <PubEntry key={p.id} p={p} />)}
-            </React.Fragment>
-          ))}
-
-          <p style={{ marginTop: 36, fontFamily: 'var(--mono)', fontSize: 11, opacity: 0.55, lineHeight: 1.6 }}>
-            For older / co-authored work, see{' '}
-            <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">
-              Google Scholar
-            </a>.{' '}·{' '}
-            <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a>
-          </p>
-        </div>
-      </div>
-
+      {mode === 'academic'
+        ? <AcademicPublications byYear={byYear} years={years} />
+        : <ClassicPublications byYear={byYear} years={years} kindCount={kindCount} />
+      }
       <Footer />
     </div>
   );

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -28,6 +28,20 @@
   text-decoration: underline;
   text-underline-offset: 4px;
 }
+.style-toggle {
+  font-family: var(--mono);
+  font-size: 10px;
+  background: none;
+  border: 1px solid var(--ink);
+  color: var(--ink);
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  letter-spacing: 0.4px;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+.style-toggle:hover { opacity: 1; background: var(--ink); color: var(--bg); }
 
 /* dark footer */
 .foot {

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,5 +1,72 @@
 /* page-specific styles */
 
+/* ============== Home — classic wireframe layout ============== */
+.home-hero {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+  gap: 36px;
+  align-items: start;
+  padding: 44px var(--page-pad-x);
+  border-bottom: var(--dash);
+}
+.home-hero h1 {
+  font-family: var(--hand);
+  font-size: 52px;
+  margin: 8px 0 0;
+  font-weight: 600;
+  line-height: 1.05;
+}
+.home-hero .lede { font-size: 13.5px; line-height: 1.7; margin-top: 16px; max-width: 620px; }
+.home-hero .ctas { display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap; align-items: center; }
+.headshot {
+  width: 220px; height: 260px;
+  border: var(--line);
+  background: repeating-linear-gradient(45deg, transparent 0 4px, var(--hatch) 4px 5px);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--mono); font-size: 10px;
+}
+.home-body {
+  padding: 36px var(--page-pad-x) 48px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 44px;
+}
+.news-list { display: flex; flex-direction: column; gap: 8px; }
+.news-item { display: flex; gap: 12px; font-size: 12px; line-height: 1.5; }
+.news-item .date {
+  font-family: var(--mono); font-size: 10px; opacity: 0.7;
+  white-space: nowrap; flex-shrink: 0; width: 64px;
+}
+.pub-row { display: flex; gap: 14px; font-size: 12px; line-height: 1.5; padding: 4px 0; }
+.pub-row .pub-title { font-weight: 600; line-height: 1.35; }
+.pub-row .pub-authors { opacity: 0.85; font-style: italic; margin-top: 2px; }
+.pub-row .pub-meta { display: flex; gap: 8px; margin-top: 5px; align-items: center; flex-wrap: wrap; }
+.pub-row .venue { font-family: var(--mono); font-size: 10px; font-weight: 700; }
+
+/* ============== Publications — classic wireframe layout ============== */
+.pub-filter {
+  padding: 14px var(--page-pad-x);
+  border-bottom: var(--dash);
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  font-family: var(--mono); font-size: 11px;
+}
+.year-head {
+  display: flex; align-items: baseline; gap: 14px;
+  margin-top: 36px; margin-bottom: 4px;
+}
+.year-head .yr { font-family: var(--hand); font-size: 38px; font-weight: 600; line-height: 1; }
+.year-head .rule { flex: 1; border-bottom: var(--line); height: 1px; }
+.pub-item {
+  display: grid;
+  grid-template-columns: 44px 110px 1fr;
+  gap: 16px;
+  padding: 16px 0;
+  border-bottom: var(--dash);
+  align-items: flex-start;
+}
+.pub-item .pub-id { font-family: var(--mono); font-size: 10px; opacity: 0.5; padding-top: 4px; }
+.pub-item .pub-title-l { font-weight: 600; line-height: 1.3; font-size: 13.5px; }
+
 /* ============== Home — academic profile layout ============== */
 /* Profile + bio section */
 .about-section {

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -1,73 +1,231 @@
 /* page-specific styles */
 
-/* ============== Home ============== */
-.home-hero {
-  display: grid;
-  grid-template-columns: 1fr 220px;
-  gap: 36px;
-  align-items: start;
-  padding: 44px var(--page-pad-x);
+/* ============== Home — academic profile layout ============== */
+/* Profile + bio section */
+.about-section {
+  display: flex;
+  gap: 52px;
+  padding: 52px var(--page-pad-x) 44px;
+  align-items: flex-start;
   border-bottom: var(--dash);
 }
-.home-hero h1 {
-  font-family: var(--hand);
-  font-size: 52px;
-  margin: 8px 0 0;
+.profile-card {
+  width: 210px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+.profile-avatar {
+  width: 190px;
+  height: 190px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: top center;
+  display: block;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.14);
+}
+.profile-name {
+  font-family: var(--body);
+  font-size: 21px;
+  font-weight: 400;
+  margin: 14px 0 3px;
+  line-height: 1.2;
+}
+.profile-sub {
+  font-size: 13px;
+  color: var(--ink-soft);
+  margin: 0 0 2px;
+  line-height: 1.45;
+}
+.profile-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 14px;
+  justify-content: center;
+}
+.soc-link, .soc-link:visited {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--link);
+  text-decoration: none;
+  border: 1px solid var(--link);
+  padding: 3px 8px;
+  border-radius: 2px;
+}
+.soc-link:hover { background: var(--link); color: #fff; }
+.cv-download, .cv-download:visited {
+  margin-top: 10px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink);
+  text-decoration: none;
+  border: 1px solid var(--ink);
+  padding: 5px 14px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.cv-download:hover { background: var(--ink); color: var(--bg); }
+/* Bio column */
+.bio-column {
+  flex: 1;
+  min-width: 0;
+  padding-top: 2px;
+}
+.bio-section-h {
+  font-family: var(--body);
+  font-size: 20px;
   font-weight: 600;
-  line-height: 1.05;
+  margin: 0 0 12px;
+  line-height: 1.2;
+  color: var(--ink);
 }
-.home-hero .lede { font-size: 13.5px; line-height: 1.7; margin-top: 16px; max-width: 620px; }
-.home-hero .ctas { display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap; align-items: center; }
-.headshot {
-  width: 220px; height: 260px;
-  border: var(--line);
-  background: repeating-linear-gradient(45deg, transparent 0 4px, var(--hatch) 4px 5px);
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--mono); font-size: 10px;
+.bio-text {
+  font-size: 15px;
+  line-height: 1.72;
+  margin: 0 0 12px;
+  color: var(--ink);
 }
-.home-body {
-  padding: 36px var(--page-pad-x) 48px;
-  display: grid;
-  grid-template-columns: 1.4fr 1fr;
-  gap: 44px;
+.bio-interests {
+  font-size: 14.5px;
+  line-height: 1.88;
+  padding-left: 18px;
+  margin: 0 0 24px;
+  color: var(--ink);
 }
-.news-list { display: flex; flex-direction: column; gap: 8px; }
-.news-item { display: flex; gap: 12px; font-size: 12px; line-height: 1.5; }
-.news-item .date {
-  font-family: var(--mono); font-size: 10px; opacity: 0.7;
-  white-space: nowrap; flex-shrink: 0; width: 64px;
+.bio-news { display: flex; flex-direction: column; gap: 5px; }
+.news-row { display: flex; gap: 14px; font-size: 13.5px; line-height: 1.55; }
+.news-date {
+  font-family: var(--mono); font-size: 10.5px;
+  opacity: 0.65; white-space: nowrap;
+  flex-shrink: 0; width: 40px; padding-top: 2px;
 }
-.pub-row { display: flex; gap: 14px; font-size: 12px; line-height: 1.5; padding: 4px 0; }
-.pub-row .pub-thumb { width: 90px; height: 64px; }
-.pub-row .pub-title { font-weight: 600; line-height: 1.35; }
-.pub-row .pub-authors { opacity: 0.85; font-style: italic; margin-top: 2px; }
-.pub-row .pub-meta { display: flex; gap: 8px; margin-top: 5px; align-items: center; flex-wrap: wrap; }
-.pub-row .venue { font-family: var(--mono); font-size: 10px; font-weight: 700; }
-
-/* ============== Publications ============== */
-.pub-filter {
-  padding: 14px var(--page-pad-x);
-  border-bottom: var(--dash);
-  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
-  font-family: var(--mono); font-size: 11px;
+/* Selected publications strip on home */
+.home-pubs-section {
+  padding: 36px var(--page-pad-x) 52px;
 }
-.year-head {
-  display: flex; align-items: baseline; gap: 14px;
-  margin-top: 36px; margin-bottom: 4px;
+.home-pubs-intro {
+  font-size: 14px;
+  opacity: 0.7;
+  margin: -6px 0 22px;
 }
-.year-head .yr { font-family: var(--hand); font-size: 38px; font-weight: 600; line-height: 1; }
-.year-head .rule { flex: 1; border-bottom: var(--line); height: 1px; }
-.pub-item {
-  display: grid;
-  grid-template-columns: 44px 110px 1fr;
-  gap: 16px;
+.home-pub-entry {
   padding: 16px 0;
-  border-bottom: var(--dash);
+  border-bottom: 1px solid rgba(0,0,0,0.07);
+}
+.home-pub-entry:last-child { border-bottom: none; }
+.home-pub-title {
+  font-size: 15.5px;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0 0 5px;
+}
+.home-pub-title a, .home-pub-title a:visited { color: var(--link); text-decoration: none; }
+.home-pub-title a:hover { text-decoration: underline; }
+.home-pub-featured {
+  display: inline-block;
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.5px;
+  background: rgba(41,98,255,0.09); color: var(--link);
+  padding: 2px 6px; border-radius: 2px; margin-left: 8px;
+  vertical-align: middle;
+}
+.home-pub-authors { font-size: 13.5px; font-style: italic; margin: 0 0 3px; opacity: 0.85; }
+.home-pub-venue { font-family: var(--mono); font-size: 11px; font-weight: 600; margin: 0 0 8px; }
+.home-pub-links { display: flex; gap: 5px; flex-wrap: wrap; }
+.pub-lnk, .pub-lnk:visited {
+  font-family: var(--mono); font-size: 10px;
+  color: var(--link); text-decoration: none;
+  border: 1px solid var(--link); padding: 2px 7px; border-radius: 2px;
+}
+.pub-lnk:hover { background: var(--link); color: #fff; }
+
+/* ============== Publications — academic list with sidebar ============== */
+.pubs-page {
+  display: flex;
   align-items: flex-start;
 }
-.pub-item .pub-id { font-family: var(--mono); font-size: 10px; opacity: 0.5; padding-top: 4px; }
-.pub-item .pub-thumb-l { width: 110px; height: 78px; }
-.pub-item .pub-title-l { font-weight: 600; line-height: 1.3; font-size: 13.5px; }
+.pubs-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  padding: 44px 20px 44px var(--page-pad-x);
+  position: sticky;
+  top: 0;
+  border-right: 1px solid rgba(0,0,0,0.07);
+}
+.sidebar-avatar {
+  width: 150px; height: 150px;
+  border-radius: 50%; object-fit: cover; object-position: top center;
+  display: block; margin-bottom: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+.sidebar-name { font-size: 15px; font-weight: 600; margin: 0 0 5px; font-family: var(--body); }
+.sidebar-bio { font-size: 12.5px; color: var(--ink-soft); line-height: 1.55; margin: 0 0 14px; }
+.sidebar-links { display: flex; flex-direction: column; gap: 4px; }
+.sidebar-links a, .sidebar-links a:visited {
+  font-size: 13px; color: var(--ink-soft); text-decoration: none; line-height: 1.65;
+}
+.sidebar-links a:hover { color: var(--link); }
+.pubs-main {
+  flex: 1; min-width: 0;
+  padding: 44px var(--page-pad-x) 56px 40px;
+}
+.pubs-page-title {
+  font-size: 26px; font-weight: 700;
+  margin: 0 0 10px; font-family: var(--body); line-height: 1.15;
+}
+.pubs-intro { font-size: 14px; opacity: 0.7; margin: 0 0 32px; line-height: 1.6; }
+.pubs-year-h {
+  font-size: 17px; font-weight: 700;
+  margin: 28px 0 12px; padding-bottom: 6px;
+  border-bottom: 1.5px solid var(--ink);
+  font-family: var(--body); letter-spacing: 0.2px;
+}
+.pubs-year-h:first-of-type { margin-top: 0; }
+.pub-entry {
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(0,0,0,0.07);
+}
+.pub-entry:last-child { border-bottom: none; }
+.pub-entry-title {
+  font-size: 15.5px; font-weight: 600; line-height: 1.4;
+  margin: 0 0 5px; font-family: var(--body);
+}
+.pub-entry-title a, .pub-entry-title a:visited { color: var(--link); text-decoration: none; }
+.pub-entry-title a:hover { text-decoration: underline; }
+.pub-entry-authors { font-size: 13.5px; font-style: italic; margin: 0 0 3px; line-height: 1.5; opacity: 0.85; }
+.pub-entry-venue { font-family: var(--mono); font-size: 11px; font-weight: 600; margin: 0 0 8px; }
+.pub-entry-feat {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.5px;
+  background: rgba(41,98,255,0.09); color: var(--link);
+  padding: 1px 5px; border-radius: 2px; margin-left: 8px;
+  vertical-align: middle;
+}
+.pub-entry-links { display: flex; gap: 5px; flex-wrap: wrap; }
+.pub-entry-lnk, .pub-entry-lnk:visited {
+  font-family: var(--mono); font-size: 10px;
+  color: var(--link); text-decoration: none;
+  border: 1px solid var(--link); padding: 2px 7px; border-radius: 2px;
+}
+.pub-entry-lnk:hover { background: var(--link); color: #fff; }
+
+/* responsive */
+@media (max-width: 820px) {
+  .about-section { flex-direction: column; gap: 28px; padding-bottom: 32px; }
+  .profile-card { width: 100%; flex-direction: row; text-align: left; gap: 22px; align-items: flex-start; }
+  .profile-avatar { width: 110px; height: 110px; flex-shrink: 0; }
+  .profile-links { justify-content: flex-start; }
+  .pubs-page { flex-direction: column; }
+  .pubs-sidebar {
+    width: 100%; position: static; border-right: none;
+    border-bottom: 1px solid rgba(0,0,0,0.07);
+    padding: 28px var(--page-pad-x);
+    display: flex; gap: 20px; align-items: flex-start;
+  }
+  .sidebar-avatar { width: 80px; height: 80px; flex-shrink: 0; }
+  .pubs-main { padding: 28px var(--page-pad-x); }
+}
 
 /* ============== Work & Projects (the spine) ============== */
 .wp-hero {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -50,4 +50,7 @@
 
   /* accent (kept neutral to match the wireframe vibe) */
   --accent: var(--ink);
+
+  /* academic link blue — used in Home & Publications academic redesign */
+  --link: #2962ff;
 }


### PR DESCRIPTION
## Summary

- **Home page** redesigned to match the Hugo Academic / Yang Liu profile style: circular portrait photo on the left, name + affiliation + social-link chips below, Bio / Research Interests / News in the right column
- **Publications page** redesigned to match the Franklin Liu AcademicPages style: sticky left sidebar (photo + author info + links) + main column with year-group dividers and flat text-based publication entries (title → PDF link, italic authors, monospace venue, badge row)
- **No thumbnail placeholder boxes** anywhere — text is the visual anchor now
- **Blue link accent** `#2962ff` added as `--link` CSS token; used for publication title links and social-link badge borders
- Mobile responsive: both pages collapse to vertical stack at ≤820 px

Reference sites:
- https://liuyang12.github.io/
- https://franklinliu.github.io/publications/

## Test plan
- [ ] Visit `/home` — circular photo, Biography section, Research Interests, News, Selected Publications all render correctly
- [ ] Visit `/pubs` — sidebar visible, year dividers (2025 / 2024 / 2023 / …), each paper has blue title link and badge chips
- [ ] Verify links work: Prof. Li Yi, Scholar, PDF badges
- [ ] Resize to <820 px — both pages collapse gracefully
- [ ] All other pages (Blog, CV, Work) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)