### PR TITLE
style: sweep remaining /data/JianWang_cv.pdf refs → May 2026 academic CV

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -8,7 +8,7 @@ export default function Footer() {
         <a href="mailto:jian004@e.ntu.edu.sg">email</a> ·{' '}
         <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">scholar</a> ·{' '}
         <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer">twitter</a> ·{' '}
-        <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">cv</a>
+        <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">cv</a>
       </span>
     </footer>
   );

--- a/src/pages/CV.jsx
+++ b/src/pages/CV.jsx
@@ -46,7 +46,7 @@ export default function CV() {
         blurb={<>Web rendering of the canonical PDF. PDF is the source of truth for committees; this page is for everyone else. PhD conferred Mar 2026.</>}
         right={
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-end' }}>
-            <Chip solid href="/data/JianWang_cv.pdf">↓ cv.pdf</Chip>
+            <Chip solid href="/data/Jian_Wang_CV_Academic_202605.pdf">↓ cv.pdf</Chip>
             <Chip sm href="/data/jornbowrl-bio.txt">↓ bio.txt</Chip>
           </div>
         }
@@ -143,7 +143,7 @@ export default function CV() {
 
         <Box dashed style={{ marginTop: 32, padding: 14, fontFamily: 'var(--mono)', fontSize: 11, display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 16 }}>
           <span>References on request — typically advisor + 2 collaborators.</span>
-          <span>↓ <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">cv.pdf</a> · ↓ <a href="/data/jornbowrl-bio.txt" target="_blank" rel="noreferrer">bio.txt</a></span>
+          <span>↓ <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">cv.pdf</a> · ↓ <a href="/data/jornbowrl-bio.txt" target="_blank" rel="noreferrer">bio.txt</a></span>
         </Box>
       </section>
 

--- a/src/pages/Publications.jsx
+++ b/src/pages/Publications.jsx
@@ -97,7 +97,7 @@ function ClassicPublications({ byYear, years, kindCount }) {
         ))}
         <Box dashed style={{ marginTop: 36, padding: 16, display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--mono)', fontSize: 11, gap: 16, flexWrap: 'wrap' }}>
           <span>For older / co-authored work, see <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.</span>
-          <span><a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a></span>
+          <span><a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a></span>
         </Box>
       </section>
     </>
@@ -151,7 +151,7 @@ function AcademicPublications({ byYear, years }) {
           <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>
           <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer">GitHub</a>
           <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer">Twitter</a>
-          <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">CV (PDF)</a>
+          <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">CV (PDF)</a>
         </div>
       </div>
 
@@ -173,7 +173,7 @@ function AcademicPublications({ byYear, years }) {
         <p style={{ marginTop: 36, fontFamily: 'var(--mono)', fontSize: 11, opacity: 0.55, lineHeight: 1.6 }}>
           For older / co-authored work, see{' '}
           <a href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ" target="_blank" rel="noreferrer">Google Scholar</a>.{' '}·{' '}
-          <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a>
+          <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">↓ cv.pdf</a>
         </p>
       </div>
     </div>

--- a/src/pages/WorkProjects.jsx
+++ b/src/pages/WorkProjects.jsx
@@ -207,7 +207,7 @@ export default function WorkProjects() {
 
         <Box dashed style={{ marginTop: 22, padding: 14, display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--mono)', fontSize: 11, flexWrap: 'wrap', gap: 16 }}>
           <span><b>How this page is organized.</b> Experience is the spine; projects and papers hang off it. For canonical chronology see <a href="/cv">CV</a>; for the full paper list see <a href="/pubs">Publications</a>.</span>
-          <span>↓ <a href="/data/JianWang_cv.pdf" target="_blank" rel="noreferrer">cv.pdf</a></span>
+          <span>↓ <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer">cv.pdf</a></span>
         </Box>
       </section>
 


### PR DESCRIPTION
## Summary

Follow-up to #70. Replaces all remaining `/data/JianWang_cv.pdf` references in the SPA with `/data/Jian_Wang_CV_Academic_202605.pdf`, so no page or component still links to the pre-2026 file.

| File | Occurrences |
|---|---|
| `src/components/Footer.jsx` | 1 |
| `src/pages/Publications.jsx` | 3 |
| `src/pages/CV.jsx` | 2 |
| `src/pages/WorkProjects.jsx` | 1 |
| **Total** | **7** |

After this merges, `grep -r JianWang_cv.pdf src/` returns nothing.

## Verification

Local vite dev server (port 9002): served sources show 7 occurrences of the new filename across the 4 files and 0 stale `JianWang_cv.pdf` references.