### PR TITLE
feat(home): bilingual CV buttons + mobile-Safari layout pass

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#fafaf7" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
     <!-- These tags are sane defaults for the SPA shell. The post-build
          prerender step (tools/build-prerender.mjs) overrides them per route

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -68,7 +68,8 @@ function ClassicHome() {
             async web framework serving 100M+ daily requests).
           </div>
           <div className="ctas">
-            <Chip solid href="/data/Jian_Wang_CV_Academic_202605.pdf">↓ Download CV</Chip>
+            <Chip solid href="/data/Jian_Wang_CV_Academic_202605.pdf">↓ CV (EN)</Chip>
+            <Chip solid href="/data/Jian_Wang_CV_Chinese_202605.pdf">↓ CV (中文)</Chip>
             <Chip href="/data/Jian_Wang_Research_Statement.pdf">Research statement</Chip>
             <Chip href="mailto:jian004@e.ntu.edu.sg">Email →</Chip>
             <Chip href="https://scholar.google.com/citations?hl=en&user=GAe_mJUAAAAJ">Scholar</Chip>
@@ -175,7 +176,10 @@ function AcademicHome() {
             <a href="https://github.com/jianwang-ntu" target="_blank" rel="noreferrer" className="soc-link">GitHub</a>
             <a href="https://twitter.com/jornbowrl" target="_blank" rel="noreferrer" className="soc-link">Twitter</a>
           </div>
-          <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer" className="cv-download">↓ Download CV</a>
+          <div className="cv-downloads">
+            <a href="/data/Jian_Wang_CV_Academic_202605.pdf" target="_blank" rel="noreferrer" className="cv-download">↓ CV (EN)</a>
+            <a href="/data/Jian_Wang_CV_Chinese_202605.pdf" target="_blank" rel="noreferrer" className="cv-download">↓ CV (中文)</a>
+          </div>
           <a href="/data/Jian_Wang_Research_Statement.pdf" target="_blank" rel="noreferrer" className="cv-download" style={{ marginTop: 6 }}>↓ Research statement</a>
         </div>
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,5 +1,11 @@
 /* base reset + body */
 * { box-sizing: border-box; }
+html {
+  /* iOS Safari rotates and "helpfully" up-sizes text by ~17% on landscape
+     rotation. Pin it to 100% so the layout stays the size we designed. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
 html, body, #root {
   margin: 0;
   padding: 0;
@@ -7,6 +13,15 @@ html, body, #root {
   font-family: var(--body);
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
+}
+body {
+  /* Mute the default blue-grey tap flash on iOS — our buttons have their
+     own hover/active states already. */
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.05);
+  /* Some descendant grids exceed the viewport on very narrow phones during
+     the brief layout flash before media queries kick in. Clamp the body so
+     iOS Safari doesn't expose a horizontal swipe. */
+  overflow-x: hidden;
 }
 a {
   color: var(--accent);
@@ -32,4 +47,8 @@ p { margin: 0 0 12px; line-height: 1.65; }
   margin: 0 auto;
   background: var(--bg);
   color: var(--ink);
+  /* Respect iPhone notch / Dynamic Island when the page is viewed full-screen
+     (PWA / standalone). Doesn't affect Safari's normal browser chrome. */
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -96,3 +96,42 @@
 .between { justify-content: space-between; }
 .mono { font-family: var(--mono); font-size: 11px; }
 .faint { opacity: 0.6; }
+
+/* ============== Mobile (≤720 px) — nav / footer / page-head ============== */
+/* The desktop layouts above assume ≥820 px of width; below that they cram
+   into a single column or overflow. Keep the desktop block intact and
+   override just what breaks on iPhone Safari. */
+@media (max-width: 720px) {
+  .nav {
+    padding: 14px var(--page-pad-x);
+    flex-wrap: wrap;
+    gap: 12px;
+    row-gap: 8px;
+  }
+  .nav .brand { font-size: 20px; }
+  .nav .links { gap: 14px; font-size: 11px; flex-wrap: wrap; }
+  .style-toggle { font-size: 9.5px; padding: 4px 9px; }
+
+  .foot {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 16px var(--page-pad-x);
+    /* On notched iPhones in standalone mode, lift the footer above the
+       home-indicator bar. */
+    padding-bottom: calc(16px + env(safe-area-inset-bottom));
+    line-height: 1.6;
+  }
+
+  .page-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 18px;
+    padding: 28px var(--page-pad-x) 22px;
+  }
+  .page-head h1 { font-size: 40px; }
+  .page-head .ph-main { max-width: 100%; }
+  .page-head .blurb { font-size: 13px; }
+
+  .content { padding: 24px var(--page-pad-x) 36px; }
+}

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -135,6 +135,17 @@
   display: inline-block;
 }
 .cv-download:hover { background: var(--ink); color: var(--bg); }
+/* Inline pair of CV chips (EN + 中文). Sits where the single CV chip used to
+   sit; wraps to a column on very narrow screens but otherwise stays inline so
+   the sidebar profile card stays compact. */
+.cv-downloads {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.cv-downloads .cv-download { margin-top: 0; }
 /* Bio column */
 .bio-column {
   flex: 1;
@@ -455,6 +466,81 @@
     grid-template-columns: 80px 1fr;
   }
   .blog-post .cover { grid-column: 2; max-width: 240px; margin-top: 10px; }
+
+  /* ----- Classic Home — stack hero, shrink headshot, single-column body */
+  .home-hero {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    padding: 28px var(--page-pad-x);
+  }
+  .home-hero h1 { font-size: 36px; }
+  .home-hero .lede { font-size: 13.5px; max-width: 100%; }
+  .home-hero .ctas { gap: 8px; }
+  .headshot {
+    width: 160px; height: 200px;
+    margin: 0 auto;
+    order: -1;            /* photo above the headline on phones */
+  }
+  .home-body {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding: 28px var(--page-pad-x) 36px;
+  }
+
+  /* ----- Academic Home — already has a 820 px breakpoint; tighten further
+     so the avatar + bio doesn't feel cramped on a 375 px iPhone. */
+  .about-section {
+    padding: 28px var(--page-pad-x) 28px;
+    gap: 22px;
+  }
+  .profile-card { flex-direction: column; text-align: center; align-items: center; gap: 14px; }
+  .profile-avatar { width: 140px; height: 140px; }
+  .profile-links { justify-content: center; }
+  .bio-section-h { font-size: 18px; }
+  .bio-text { font-size: 14.5px; }
+  .bio-interests { font-size: 14px; }
+  .home-pubs-section { padding: 28px var(--page-pad-x) 40px; }
+
+  /* ----- Publications — already mostly handled at 820 px, but tap targets
+     and font sizes need a touch more care on phones. */
+  .pubs-sidebar { flex-direction: column; gap: 12px; padding: 22px var(--page-pad-x); }
+  .pubs-page-title { font-size: 22px; }
+
+  /* ----- Work & Projects — desktop assumes ≥820 px and starts to overflow
+     below that. Stack the grid, soften the timeline indent, and let the
+     two-column body inside each row collapse. */
+  .wp-hero { padding: 28px var(--page-pad-x) 22px; }
+  .wp-hero h1 { font-size: 40px; }
+  .wp-grid { grid-template-columns: 1fr; gap: 22px; margin-top: 14px; }
+  .wp-stats {
+    border-left: none; padding-left: 0;
+    border-top: var(--dash); padding-top: 18px;
+  }
+  .wp-stat .v { font-size: 40px; }
+  .wp-view { padding: 12px var(--page-pad-x); font-size: 10.5px; }
+  .wp-row { grid-template-columns: 72px 20px 1fr; }
+  .wp-row .wp-when { padding-right: 8px; }
+  .wp-row .body .role { font-size: 22px; }
+  .wp-row .body .two { grid-template-columns: 1fr; gap: 12px; }
+
+  /* ----- Matrix — 4 columns is too wide for a phone. Two columns + drop
+     the inner vertical rule. */
+  .matrix { grid-template-columns: 1fr 1fr; font-size: 11.5px; }
+  .matrix .cell.r { border-right: none; }
+  .matrix .cell { padding: 8px 10px; }
+
+  /* ----- CV — the desktop two-column "when | body" layout doesn't fit
+     under a 375 px viewport. Stack instead. */
+  .cv-block { grid-template-columns: 1fr; gap: 6px; padding: 12px 0; }
+  .cv-block .when { font-size: 10.5px; }
+  .cv-section-h h2 { font-size: 26px; }
+
+  /* ----- Blog single-post body — keep code blocks scrollable, not breaking
+     the page on iOS Safari. */
+  .blog-body { font-size: 14.5px; line-height: 1.7; }
+  .blog-body h1 { font-size: 30px; }
+  .blog-body h2 { font-size: 22px; }
+  .blog-body pre { font-size: 12px; -webkit-overflow-scrolling: touch; }
 }
 
 /* Single-post body: long-form markdown rendered with react-markdown. */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -47,6 +47,17 @@
   /* layout */
   --page-w: 1180px;
   --page-pad-x: 56px;
+}
+
+/* Tablet — slightly tighter side padding so the content has room. */
+@media (max-width: 900px) {
+  :root { --page-pad-x: 32px; }
+}
+
+/* Phone — 56 px of side padding on a 375 px iPhone leaves under 270 px of
+   usable content. Drop to 18 px and let lines breathe. */
+@media (max-width: 560px) {
+  :root { --page-pad-x: 18px; }
 
   /* accent (kept neutral to match the wireframe vibe) */
   --accent: var(--ink);


### PR DESCRIPTION
## Summary

Two related changes that together make the homepage feel intentional on a phone:

### 1. Bilingual CV chips
The single "Download CV" button is now two chips — `↓ CV (EN)` (the May 2026 academic CV) and `↓ CV (中文)` (the new Chinese CV). Applied to both Home layouts (Classic hero CTA row, Academic profile card). The Academic mode gets a new `.cv-downloads` flex wrapper so the pair sits as one tight row above the Research-statement link.

### 2. Mobile-Safari layout pass
Until now the CSS only had one breakpoint (`@media (max-width: 820px)`) and it only touched `.about-section` and `.pubs-page`. Below that, Classic Home, Work & Projects, CV, page-head, nav, and footer kept their desktop grids and either overflowed the iPhone viewport or collapsed into an unreadable cram.

Added a single `@media (max-width: 720px)` block per stylesheet, plus iOS-specific base tweaks:

- **Shrink `--page-pad-x`** from 56 px → 32 px (≤900 px) → 18 px (≤560 px). The old 56 px ate ~30% of a 375 px iPhone.
- **Stack `.home-hero`** (Classic) into one column, reorder the AI headshot above the headline (`order: -1`), shrink h1 to 36 px.
- **Stack `.home-body`, `.wp-grid`, `.wp-row .two`, `.cv-block`, `.page-head`** into one column.
- **`.matrix`** drops from 4 columns to 2 on phones and removes the inner vertical rule.
- **`.nav`** wraps to multiple rows; **`.foot`** stacks and respects `env(safe-area-inset-bottom)` for PWA on notched iPhones.
- **`-webkit-text-size-adjust: 100%`** to stop Safari's landscape auto-upsize; **`-webkit-tap-highlight-color`** to mute the blue tap flash; **`overflow-x: hidden`** on body as a defensive guard; **`env(safe-area-inset-left/right)`** on `.page` for notched-iPhone PWA.
- **`index.html`** — viewport now `viewport-fit=cover` + `theme-color` + `apple-mobile-web-app-*` so installed-as-PWA gets the correct status-bar treatment.

## Verification

| Width | Result |
|---|---|
| 1280 × 900 (desktop) | No regression — hero cols still `812px 220px`, h1 52 px |
| 375 × 812 (iPhone X/12) | Hero stacks, both CV chips inline, nav wraps cleanly, no horizontal scroll |
| 320 × 568 (iPhone SE) | Layout still holds; nav wraps to 3 rows; headshot centers; lede readable |

Screenshots in the next reply if useful.