### PR TITLE
chore(seo): refresh sitemap + wire og:image on two paper posts

### DIFF
--- a/public/blog/leworldmodel-simplifying-joint-embedding-predictive/meta.json
+++ b/public/blog/leworldmodel-simplifying-joint-embedding-predictive/meta.json
@@ -11,5 +11,6 @@
   "title_zh": "LeWorldModel：从像素中稳定学习世界模型的新方法",
   "dek_zh": "本文提出了一种名为LeWorldModel（LeWM）的新方法，旨在在紧凑的潜在空间中稳定学习世界模型。这种方法克服了现有联合嵌入预测架构（JEPAs）在训练过程中的不稳定性问题，并实现了全栈端到端的训练，从而无需依赖复杂的多项损失函数、预训练编码器或外部监督信息。",
   "source": "https://arxiv.org/pdf/2603.19312",
-  "source_kind": "paper"
+  "source_kind": "paper",
+  "image": "/images/blog/leworldmodel-simplifying-joint-embedding-predictive_diagram.png"
 }

--- a/public/blog/meta-harness-letting-a-coding-agent-redesign-its-own/meta.json
+++ b/public/blog/meta-harness-letting-a-coding-agent-redesign-its-own/meta.json
@@ -12,6 +12,7 @@
   "dek_zh": "Stanford、KRAFTON 和 MIT 团队（Lee 等人）提出的这篇论文把\"harness 工程\"——围绕大模型编写的存储、检索和上下文构造代码——变成了一个可自动搜索的问题。作者们的核心主张是：现有文本优化器之所以不擅长这件事，是因为它们把反馈压缩得太狠；只要让一个编码 Agent 通过文件系统读到所有历史代码、分数和执行轨迹，自动化的 harness 搜索就能在三个差异巨大的领域上击败手工设计的最强方案。",
   "source": "https://arxiv.org/pdf/2603.28052",
   "source_kind": "paper",
+  "image": "/images/blog/meta-harness-letting-a-coding-agent-redesign-its-own_diagram.png",
   "labels": [
     "topic:agents",
     "topic:research",

--- a/public/blog/posts.json
+++ b/public/blog/posts.json
@@ -60,7 +60,8 @@
     "title_zh": "LeWorldModel：从像素中稳定学习世界模型的新方法",
     "dek_zh": "本文提出了一种名为LeWorldModel（LeWM）的新方法，旨在在紧凑的潜在空间中稳定学习世界模型。这种方法克服了现有联合嵌入预测架构（JEPAs）在训练过程中的不稳定性问题，并实现了全栈端到端的训练，从而无需依赖复杂的多项损失函数、预训练编码器或外部监督信息。",
     "source": "https://arxiv.org/pdf/2603.19312",
-    "source_kind": "paper"
+    "source_kind": "paper",
+    "image": "/images/blog/leworldmodel-simplifying-joint-embedding-predictive_diagram.png"
   },
   {
     "slug": "riding-the-exponential-how-anthropic-navigates-rapid-growth",
@@ -189,7 +190,8 @@
       "topic:engineering",
       "format:paper",
       "speaker:academia"
-    ]
+    ],
+    "image": "/images/blog/meta-harness-letting-a-coding-agent-redesign-its-own_diagram.png"
   },
   {
     "slug": "code-world-models-asking-the-llm-to-write-the-game-not-play",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,33 +2,123 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.wj2ai.com/home</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.wj2ai.com/pubs</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.wj2ai.com/work</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.wj2ai.com/cv</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.wj2ai.com/blog</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/demystifying-the-inner-workings-of-ai-models-the-role-of</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/airbnb-ceo-brian-chesky-advocates-for-founder-mode</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/how-ai-agents-are-defining-the-future-of-technology</loc>
+    <lastmod>2026-05-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/leworldmodel-simplifying-joint-embedding-predictive</loc>
+    <lastmod>2026-05-17</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/riding-the-exponential-how-anthropic-navigates-rapid-growth</loc>
+    <lastmod>2026-05-17</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/eric-schmidt-ai-warfare-china</loc>
+    <lastmod>2026-05-17</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/thinking-machines-labs-interaction-model-making</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/builders-win-information-movers-dont-nikhyl-singhal-on-the</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/drive-it-like-its-stolen-max-shying-on-agency-malleable</loc>
+    <lastmod>2026-05-14</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/meta-harness-letting-a-coding-agent-redesign-its-own</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/code-world-models-asking-the-llm-to-write-the-game-not-play</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/hitting-breakouts-perfect-score-without-training-a-single</loc>
+    <lastmod>2026-05-12</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/the-road-to-alphafold-how-deepmind-bet-on-agi-and-cracked</loc>
+    <lastmod>2026-05-11</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/demis-hassabis-on-the-through-line-from-theme-park-to-agi</loc>
+    <lastmod>2026-05-11</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.wj2ai.com/blog/andrej-karpathy-on-ai-psychosis-auto-research-and-why-he</loc>
+    <lastmod>2026-05-11</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.wj2ai.com/blog/a16zs-case-for-continual-learning-llms-are-stuck-in-memento</loc>

--- a/tools/build-sitemap.mjs
+++ b/tools/build-sitemap.mjs
@@ -42,9 +42,20 @@ try {
 
 const escape = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
+// The /blog index page changes whenever a new post lands. Track its lastmod
+// to the newest post's date rather than today — that way the sitemap doesn't
+// claim freshness it doesn't have on a quiet day, and a crawler reading the
+// sitemap weekly sees the index move only when content actually moves.
+const newestPostDate = posts
+  .map((p) => p?.date)
+  .filter(Boolean)
+  .sort()
+  .at(-1) || today;
+
 const urls = [];
 for (const r of STATIC_ROUTES) {
-  urls.push({ loc: `${SITE_URL}${r.path}`, lastmod: today, changefreq: r.changefreq, priority: r.priority });
+  const lastmod = r.path === '/blog' ? newestPostDate : today;
+  urls.push({ loc: `${SITE_URL}${r.path}`, lastmod, changefreq: r.changefreq, priority: r.priority });
 }
 for (const p of posts) {
   if (!p?.slug) continue;


### PR DESCRIPTION
## Summary

Three small SEO updates after the recent batch of blog posts landed:

### 1. Sitemap regenerated

The committed `public/sitemap.xml` was frozen at 2026-05-10 and only listed 18 of the current 33 blog posts — `master` was missing 15 URLs. Ran `npm run prebuild` and committed the fresh output: **38 URLs** (5 static + 33 blog), each blog entry's `<lastmod>` driven by its post's `date` from `meta.json` rather than build time.

> The live site has always served a fresh sitemap because the deploy workflow re-runs `prebuild` on every push. Committing the regenerated copy keeps the source-of-truth aligned with what's actually served.

### 2. Two paper posts: og:image was falling back to the favicon

`leworldmodel-...` and `meta-harness-...` are paper-source posts. The pipeline generated a `*_diagram.png` for each but never wrote an `image` field into `meta.json`. `BlogPost.jsx` and `build-prerender.mjs` both fall back to the favicon when `meta.image` is missing — so social-share unfurls of these two posts have been showing a 16×16 favicon as the og:image instead of the diagram.

Fixed by pointing the `image` field at the existing `_diagram.png` for both posts. Updated:
- `public/blog/leworldmodel-simplifying-joint-embedding-predictive/meta.json`
- `public/blog/meta-harness-letting-a-coding-agent-redesign-its-own/meta.json`
- `public/blog/posts.json` (mirror entries)

### 3. `/blog` index lastmod tracks newest post

`tools/build-sitemap.mjs` used to set `lastmod` for every static route to today. Now the `/blog` index uses the newest post's `date` instead (other static routes still use today). A crawler reading the sitemap weekly only sees `/blog` move when a post actually lands — fewer false-positive change signals.

### Known gap

`harness-engineering-how-openais-ryan-lapopolo-builds` still has no `image` (no diagram or cover was generated for it). Needs a one-off cover-image render in a follow-up; out of scope here.